### PR TITLE
Fix docker-compose start up order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,13 @@ COPY . /app/
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
   apt update && \
-  apt install -y git ruby-dev nodejs && \
+  apt install -y git ruby-dev nodejs postgresql-client && \
+  apt clean && \
   gem install compass sass && \
   npm -g install less && \
-  pip install -r requirements.txt && \
-  pip install redis coveralls
+  pip install --no-cache-dir -r requirements.txt && \
+  pip install --no-cache-dir redis
 
-RUN chmod +x /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh \
+  /app/wait-for-postgres.sh
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/db.env
+++ b/db.env
@@ -1,0 +1,6 @@
+# Database environment variables
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=root
+POSTGRES_DB=dj_crm
+DB_HOST=db
+DB_PORT=5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,17 +5,14 @@ services:
     image: postgres
     # volumes:
     #   - /home/db:/var/lib/postgresql/data
-    environment:
-      POSTGRES_PASSWORD: "root"
-      POSTGRES_USER: "postgres"
-      POSTGRES_DB: "dj_crm"
+    env_file: 
+      - ./db.env
 
   web:
     build: .
     image: micropyramid/django-crm:1
-    environment:
-      DB_HOST: db
-      DB_PORT: 5432
+    env_file: 
+      - ./db.env
     ports:
       - "8001:8000"
     depends_on:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Execute startup scripts
+./wait-for-postgres.sh $DB_HOST
 python manage.py collectstatic --noinput
 python manage.py migrate
 python manage.py runserver 0.0.0.0:8000

--- a/wait-for-postgres.sh
+++ b/wait-for-postgres.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# wait-for-postgres.sh
+
+set -e
+
+host="$1"
+shift
+cmd="$@"
+
+echo "Testing Postgres connection with psql ..."
+until PGPASSWORD=$POSTGRES_PASSWORD psql -h "$host" -U "postgres" -c '\q'; do
+  #~ >&2 echo "Postgres is unavailable - sleeping"
+  >&2 echo -n .
+  sleep 1
+done
+
+>&2 echo "Postgres is up - executing command"
+exec $cmd


### PR DESCRIPTION
I found that last PR #216 have some problem. If CRM container be ready faster than DB container, build by docker-compose will failed.

db.env is for storing shared database environment variables
wait-for-postgres.sh is for waiting DB container ready to connect