### PR TITLE
Adding missing tag for bootstrap on root.html

### DIFF
--- a/templates/root.html
+++ b/templates/root.html
@@ -11,7 +11,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Django CRM</title>
   <link href="https://fonts.googleapis.com/css?family=Muli" rel="stylesheet">
-
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.47/css/bootstrap-datetimepicker.min.css" />
 
   <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">


### PR DESCRIPTION
The `template/root.html` file is missing the tag that calls `bootstrap`, making the page to not render properly.