### PR TITLE
docs: Fix simple typo, uniaue -> unique

### DIFF
--- a/marketing/views.py
+++ b/marketing/views.py
@@ -630,7 +630,7 @@ def campaign_new(request):
             for e in links:
                 llist.append(e.get('href'))
 
-            # get unique linnk
+            # get unique link
             links = set(llist)
 
             # Replace Links with new One

--- a/marketing/views.py
+++ b/marketing/views.py
@@ -630,7 +630,7 @@ def campaign_new(request):
             for e in links:
                 llist.append(e.get('href'))
 
-            # get uniaue linnk
+            # get unique linnk
             links = set(llist)
 
             # Replace Links with new One

--- a/static/js/ajaxForm.js
+++ b/static/js/ajaxForm.js
@@ -114,7 +114,7 @@ $.fn.ajaxSubmit = function(options) {
     url = (typeof action === 'string') ? $.trim(action) : '';
     url = url || window.location.href || '';
     if (url) {
-        // clean url (don't include hash vaue)
+        // clean url (don't include hash value)
         url = (url.match(/^([^#]+)/)||[])[1];
     }
 


### PR DESCRIPTION
There is a small typo in marketing/views.py.

Should read `unique` rather than `uniaue`.

