### PR TITLE
Update Dockerfile to have fast regular build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6
 WORKDIR /app
 
 # Intall dependencies
-COPY . /app/
+COPY requirements.txt /app/
 
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
   apt update && \
@@ -13,6 +13,8 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
   npm -g install less && \
   pip install --no-cache-dir -r requirements.txt && \
   pip install --no-cache-dir redis
+
+COPY . /app/
 
 RUN chmod +x /app/entrypoint.sh \
   /app/wait-for-postgres.sh


### PR DESCRIPTION
Update the Dockerfile to firstly copying the requirement.txt only to the system and installing the required dependencies and then only the whole code.
which helps to keep the required package installed and system packages pull from the previous images created.
Closes #403 