### PR TITLE
Avoid css compression

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -13,10 +13,8 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datetimepicker/4.17.47/css/bootstrap-datetimepicker.min.css" />
 
-    {% compress css %}
     <link href="{% static 'css/main.scss' %}" type="text/x-scss" rel="stylesheet">
     <link href="{% static 'css/mention.scss' %}" type="text/x-scss" rel="stylesheet">
-    {% endcompress %}
     {% block extralinks %} {% endblock %}
   </head>
   <body class="main_body_bg_color">


### PR DESCRIPTION
This PR removes css compression in `templates/base.html`

For more details on the reson behind this PR see: #426