### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ virtualenv venv
 source venv/bin/activate
 ```
 
-* Install the project's dependencie
+* Install the project's dependency
 
 ```
 pip install -r requirements.txt

--- a/docs/source/Forget Password.rst
+++ b/docs/source/Forget Password.rst
@@ -9,7 +9,7 @@ Forget Password
 
 |  **Fig** Email Sent acknowledgement view
 
-|  When you check the mail you will recieve a email similar to the below figure.
+|  When you check the mail you will receive a email similar to the below figure.
 
 
 |  **Fig** Email recieved

--- a/installation.md
+++ b/installation.md
@@ -5,7 +5,7 @@
 docker pull micropyramid/crm:0.1
 ```
 
-- setup environment variables, below varialbes are required.
+- setup environment variables, below variables are required.
 ```sh
 # environment type, eg: stage, live
 export ENV_TYPE=""


### PR DESCRIPTION
There are small typos in:
- README.md
- docs/source/Forget Password.rst
- installation.md

Fixes:
- Should read `variables` rather than `varialbes`.
- Should read `receive` rather than `recieve`.
- Should read `dependency` rather than `dependencie`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md