### PR TITLE
Few Bugs Fixed

### DIFF
--- a/common/serializer.py
+++ b/common/serializer.py
@@ -184,7 +184,7 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class ProfileSerializer(serializers.ModelSerializer):
-    address = BillingAddressSerializer()
+    # address = BillingAddressSerializer()
 
     class Meta:
         model = Profile

--- a/common/serializer.py
+++ b/common/serializer.py
@@ -184,7 +184,6 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class ProfileSerializer(serializers.ModelSerializer):
-    # address = BillingAddressSerializer()
 
     class Meta:
         model = Profile

--- a/teams/urls.py
+++ b/teams/urls.py
@@ -6,5 +6,5 @@ app_name = "api_leads"
 
 urlpatterns = [
     path("", views.TeamsListView.as_view()),
-    path("<int:pk>/", views.TeamsDetailView.as_view()),
+    path("<str:pk>/", views.TeamsDetailView.as_view()),
 ]

--- a/teams/views.py
+++ b/teams/views.py
@@ -150,7 +150,7 @@ class TeamsDetailView(APIView):
 
             team_obj.users.clear()
             if params.get("assign_users"):
-                assinged_to_list = json.loads(params.get("assign_users"))
+                assinged_to_list = params.get("assign_users")
                 profiles = Profile.objects.filter(
                     id__in=assinged_to_list, org=request.profile.org
                 )


### PR DESCRIPTION
I  made three changes. 
### common/serializer.py  1023b9ac57dc264aa2136918c437744fdaf7390b
Resolving `AttributeError at /api/teams/ 'User' object has no attribute 'address'`
Also, getting an address from `BillingAddressSerializer()` is unnecessary. It is already available in the `Profile` model.

### teams/urls.py d3c63bb51347c7396e2058e4156214ced5a3ee3a
Team ID is in UUID format, so its datatype must be a string. 

### teams/views.py aea05e85dccb40c5623382e2449f3004fdf480ac
The `assigned_to_list` variable must be a list object, and it already comes in `params`. No need to parse it.