### PR TITLE
Make local dev work

### DIFF
--- a/crm/celery.py
+++ b/crm/celery.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+import django.conf as conf
 
 from celery import Celery
 
@@ -18,4 +19,4 @@ app = Celery("crm")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 
 # Load task modules from all registered Django app configs.
-app.autodiscover_tasks()
+app.autodiscover_tasks(lambda: conf.settings.INSTALLED_APPS)

--- a/docker/celery.dockerfile
+++ b/docker/celery.dockerfile
@@ -1,19 +1,9 @@
-FROM ubuntu:22.04
-
-ARG DEBIAN_FRONTEND=noninteractive
-ARG PIP_EXTRA_INDEX_URL
-
-WORKDIR /app
+FROM common-bottle-dockerfile
 
 # Intall dependencies
 COPY requirements.txt /app
 
-RUN apt-get update -y
-RUN apt install -y git ruby-dev ruby-ffi redis-server wkhtmltopdf
-RUN apt clean
-RUN apt install -y python3-pip
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
-RUN python3 -m pip install --no-cache-dir redis
 
 COPY . /app
 

--- a/docker/celery.dockerfile
+++ b/docker/celery.dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PIP_EXTRA_INDEX_URL
+
+WORKDIR /app
+
+# Intall dependencies
+COPY requirements.txt /app
+
+RUN apt-get update -y
+RUN apt install -y git ruby-dev ruby-ffi redis-server wkhtmltopdf
+RUN apt clean
+RUN apt install -y python3-pip
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
+RUN python3 -m pip install --no-cache-dir redis
+
+COPY . /app
+
+ENTRYPOINT ["celery", "-A", "crm", "worker"]
+CMD ["--loglevel=INFO"]

--- a/docker/common.dockerfile
+++ b/docker/common.dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG PIP_EXTRA_INDEX_URL
+
+WORKDIR /app
+
+RUN apt-get update -y
+RUN apt install -y git ruby-dev ruby-ffi redis-server wkhtmltopdf
+RUN apt clean
+RUN apt install -y python3-pip
+RUN python3 -m pip install --no-cache-dir redis

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,22 @@
 version: '3'
 services:
+  celery:
+    image: celery-bottlecrm-broker
+    build:
+      context: ..
+      dockerfile: docker/celery.dockerfile
+    container_name: celery-bottlecrm
+    depends_on:
+      - crm-app
+      - redis
+    networks:
+      - custom_network
+
   crm-app:
     image: djcrm:1
+    build:
+      context: ..
+      dockerfile: docker/dockerfile
     container_name: crm-app
     environment:
       - DBNAME=crm
@@ -9,27 +24,42 @@ services:
       - DBPASSWORD=crm
       - DBHOST=crm-db
       - DBPORT=5432
-
     depends_on:
       - crm-db
+      - redis
     ports:
-      - 8000:8000
+      - "8000:8000"
     networks:
-      - nw
+      - custom_network
+
+  redis:
+    image: redis:latest
+    container_name: redis-bottlecrm
+    ports:
+      - "6379:6379"
+    networks:
+      - custom_network
 
   crm-db:
     image: postgres:latest
     container_name: crm-db
+    volumes:
+      - /var/lib/containers/storage/volumes/bottlecrm/_data:/var/lib/postgresql/data/pgdata
     environment:
+      - PGDATA=/var/lib/postgresql/data/pgdata
+      - PGHOST=localhost
+      - PGPORT=5432
       - POSTGRES_DB=crm
+      - PGDATABASE=crm
       - POSTGRES_USER=crm
+      - PGUSER=crm
       - POSTGRES_PASSWORD=crm
     ports:
-      - 5432:5432
-    volumes:
-      - /var/run/postgresql/:/var/run/postgresql
+      - "5432:5432"
     networks:
-      - nw
+      - custom_network
 
 networks:
-  nw: {}
+  custom_network:
+    driver: bridge
+

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -5,10 +5,7 @@ ARG PIP_EXTRA_INDEX_URL
 
 WORKDIR /app
 
-# Intall dependencies
-COPY requirements.txt /app
-
-RUN apt update
+RUN apt update -y
 RUN apt install -y git ruby-dev ruby-ffi postgresql-client redis-server wkhtmltopdf
 RUN apt clean
 RUN gem install sass
@@ -18,6 +15,10 @@ RUN gem install compass
 RUN apt install nodejs npm -y
 RUN npm -g install less
 RUN apt install -y python3-pip
+
+# Install dependencies
+COPY requirements.txt /app
+
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
 RUN python3 -m pip install --no-cache-dir redis
 

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,31 +1,21 @@
-FROM ubuntu:22.04
+FROM common-bottle-dockerfile
 
-ARG DEBIAN_FRONTEND=noninteractive
-ARG PIP_EXTRA_INDEX_URL
-
-WORKDIR /app
-
-RUN apt update -y
-RUN apt install -y git ruby-dev ruby-ffi postgresql-client redis-server wkhtmltopdf
-RUN apt clean
 RUN gem install sass
 RUN gem install compass
 # install nvm/npm
 # RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
 RUN apt install nodejs npm -y
 RUN npm -g install less
-RUN apt install -y python3-pip
+
+RUN apt install -y postgresql-client
 
 # Install dependencies
 COPY requirements.txt /app
 
 RUN python3 -m pip install --no-cache-dir -r requirements.txt
-RUN python3 -m pip install --no-cache-dir redis
-
 COPY . /app
 COPY docker/entrypoint.sh /app
 COPY docker/wait-for-postgres.sh /app
-
 
 RUN chmod +x entrypoint.sh 
 RUN chmod +x wait-for-postgres.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ django_storages==1.13.2
 drf-rw-serializers==1.0.5
 django-crum==0.7.9
 Redis==4.6.0
+SQLAlchemy==2.0.28
 # remove it
 django-phonenumber-field==7.1.0
 arrow==1.2.3


### PR DESCRIPTION
Given the following instance of a .env file, the backend localhost for dev works:

```env

# Environment variables

SECRET_KEY="mco934$@)NHUYTC%6789"
ENV_TYPE="dev"
DOMAIN_NAME="localhost"

# AWS
AWS_BUCKET_NAME=""

AWS_ACCESS_KEY_ID=""
AWS_SECRET_ACCESS_KEY=""
AWS_SES_REGION_NAME=""
AWS_SES_REGION_ENDPOINT=""

# DB
DBNAME="crm"
DBUSER="crm"
DBPASSWORD="crm"
DBHOST="localhost"
DBPORT="5432"

# Sentry
SENTRY_DSN=""

# Celery
CELERY_BROKER_URL="redis://redis-bottlecrm:6379/0"
CELERY_RESULT_BACKEND="db+sqlite:///results.db"

# Swagger
SWAGGER_ROOT_URL=""

#CACHES
MEMCACHELOCATION=""

# Email
DEFAULT_FROM_EMAIL=""
ADMIN_EMAIL=""
```