### PR TITLE
fix(docs): update Swagger URL in README for API exploration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ docker-compose -f docker/docker-compose.yml up
 python manage.py migrate
 python manage.py runserver
 ```
-- Then open http://localhost:8000/swagger/ in your browser to explore API.
+- Then open http://localhost:8000/swagger-ui/ in your browser to explore API.
 
 - After running API, Go to Frontend UI [React CRM](https://github.com/MicroPyramid/react-crm "React CRM") project to configure Fronted UI to interact with API.
 


### PR DESCRIPTION
- Changed URL from `/swagger/` to `/swagger-ui/` to match correct Swagger endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the URL for accessing API documentation in the README file.
	- Clarified instructions for configuring the Frontend UI project to interact with the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->