### PR TITLE
Potential fix for code scanning alert no. 9: Clear-text logging of sensitive information

### DIFF
--- a/backend/common/external_auth.py
+++ b/backend/common/external_auth.py
@@ -46,7 +46,7 @@ class APIKeyAuthentication(BaseAuthentication):
             return (profile.user, None)
 
         except Org.DoesNotExist:
-            logger.warning(f"Invalid API key attempted: {api_key[:8]}...")
+            logger.warning("Invalid API key attempted")
             raise AuthenticationFailed("Invalid API Key")
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/MicroPyramid/Django-CRM/security/code-scanning/9](https://github.com/MicroPyramid/Django-CRM/security/code-scanning/9)

To fix the problem, we should ensure that sensitive information such as API keys is never logged (even partially masked) in production code. The solution is to alter or remove the log line on line 49 in `backend/common/external_auth.py`. The best approach, which retains useful logging for future debugging while protecting secrets, is to log the event generically, without any part of the API key—simply recording that an invalid API key was attempted, perhaps with request meta information that does not contain secrets. The log message can be changed from  

```python
logger.warning(f"Invalid API key attempted: {api_key[:8]}...")
```
to  

```python
logger.warning("Invalid API key attempted")
```
or, if further context is needed, include the requester's IP address or similar metadata—but never any part of the secret.

**What is needed:**  
Only the specified logging call needs to be updated. No new imports, methods, or definitions are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
