### PR TITLE
fix: remove URL from activation email recipients list

### DIFF
--- a/backend/common/tasks.py
+++ b/backend/common/tasks.py
@@ -246,8 +246,7 @@ def resend_activation_link_to_user(
             context["token"],
             activation_key,
         )
-        recipients = [context["complete_url"]]
-        recipients.append(user_email)
+        recipients = [user_email]
         subject = "Welcome to Bottle CRM"
         html_content = render_to_string("user_status_in.html", context=context)
         if recipients:


### PR DESCRIPTION
## Summary
- Fix bug where activation URL was added to `EmailMessage` recipients list instead of only email addresses

## Problem
In `resend_activation_link_to_user` (`common/tasks.py`), the recipients list was:
```python
recipients = [context["complete_url"]]   # a URL, not an email
recipients.append(user_email)
```
This passed the activation URL as an email recipient, which is invalid. The URL is already available in the template context for rendering in the email body.

## Fix
```python
recipients = [user_email]
```

Fixes #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected activation email delivery to ensure emails are sent properly to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->