### PR TITLE
security: stop leaking exception details in API responses

### DIFF
--- a/backend/common/views/auth_views.py
+++ b/backend/common/views/auth_views.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import secrets
 
 import requests
@@ -16,6 +17,8 @@ from rest_framework_simplejwt.tokens import RefreshToken
 
 from common import serializer
 from common.models import Org, Profile, User
+
+logger = logging.getLogger(__name__)
 from common.serializer import OrgAwareRefreshToken
 
 
@@ -192,9 +195,10 @@ class GoogleIdTokenView(APIView):
             )
             email = idinfo.get("email")
             picture = idinfo.get("picture", "")
-        except ValueError as e:
+        except ValueError:
+            logger.warning("Google OAuth token validation failed", exc_info=True)
             return Response(
-                {"error": f"Invalid token: {str(e)}"},
+                {"error": "Invalid token"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/backend/invoices/api_views.py
+++ b/backend/invoices/api_views.py
@@ -1,3 +1,4 @@
+import logging
 from decimal import Decimal
 
 from django.conf import settings
@@ -13,6 +14,8 @@ from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+logger = logging.getLogger(__name__)
 
 from common.models import Attachments, Comment
 from common.permissions import HasOrgContext
@@ -561,14 +564,16 @@ class InvoicePDFView(APIView):
             response = HttpResponse(pdf_content, content_type="application/pdf")
             response["Content-Disposition"] = f'attachment; filename="{filename}"'
             return response
-        except ImportError as e:
+        except ImportError:
+            logger.exception("PDF generation library not available")
             return Response(
-                {"error": True, "message": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                {"error": True, "message": "PDF generation unavailable"},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to generate invoice PDF")
             return Response(
-                {"error": True, "message": f"Error generating PDF: {str(e)}"},
+                {"error": True, "message": "Failed to generate PDF"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -1197,14 +1202,16 @@ class EstimatePDFView(APIView):
             response = HttpResponse(pdf_content, content_type="application/pdf")
             response["Content-Disposition"] = f'attachment; filename="{filename}"'
             return response
-        except ImportError as e:
+        except ImportError:
+            logger.exception("PDF generation library not available")
             return Response(
-                {"error": True, "message": str(e)},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                {"error": True, "message": "PDF generation unavailable"},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to generate estimate PDF")
             return Response(
-                {"error": True, "message": f"Error generating PDF: {str(e)}"},
+                {"error": True, "message": "Failed to generate PDF"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 

--- a/backend/invoices/public_views.py
+++ b/backend/invoices/public_views.py
@@ -4,11 +4,15 @@ Public views for client portal.
 These views do not require authentication and are accessed via public tokens.
 """
 
+import logging
+
 from django.http import HttpResponse
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+logger = logging.getLogger(__name__)
 
 from invoices.models import Invoice, Estimate, InvoiceTemplate
 from invoices.pdf import (
@@ -147,14 +151,16 @@ class PublicInvoicePDFView(APIView):
             response = HttpResponse(pdf_content, content_type="application/pdf")
             response["Content-Disposition"] = f'attachment; filename="{filename}"'
             return response
-        except ImportError as e:
+        except ImportError:
+            logger.exception("PDF generation library not available")
             return Response(
-                {"error": True, "message": f"PDF generation unavailable: {str(e)}"},
+                {"error": True, "message": "PDF generation unavailable"},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to generate invoice PDF")
             return Response(
-                {"error": True, "message": f"Failed to generate PDF: {str(e)}"},
+                {"error": True, "message": "Failed to generate PDF"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -278,14 +284,16 @@ class PublicEstimatePDFView(APIView):
             response = HttpResponse(pdf_content, content_type="application/pdf")
             response["Content-Disposition"] = f'attachment; filename="{filename}"'
             return response
-        except ImportError as e:
+        except ImportError:
+            logger.exception("PDF generation library not available")
             return Response(
-                {"error": True, "message": f"PDF generation unavailable: {str(e)}"},
+                {"error": True, "message": "PDF generation unavailable"},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
-        except Exception as e:
+        except Exception:
+            logger.exception("Failed to generate estimate PDF")
             return Response(
-                {"error": True, "message": f"Failed to generate PDF: {str(e)}"},
+                {"error": True, "message": "Failed to generate PDF"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 


### PR DESCRIPTION
## Summary

- **Replace `str(e)` in API error responses with generic messages** — exception details (stack traces, file paths, library versions) were being sent to clients
- **Log actual exceptions server-side** via `logger.exception()` / `logger.warning()` so they're still available for debugging

Fixes all 9 CodeQL "information exposure through an exception" alerts:

| File | Lines | Context |
|------|-------|---------|
| `common/views/auth_views.py` | 197 | Google OAuth token validation |
| `invoices/public_views.py` | 152, 157 | Public invoice PDF generation |
| `invoices/public_views.py` | 283, 288 | Public estimate PDF generation |
| `invoices/api_views.py` | 566, 571 | Invoice PDF generation |
| `invoices/api_views.py` | 1202, 1207 | Estimate PDF generation |

Also corrected `ImportError` HTTP status from 500 to 503 (Service Unavailable) in `api_views.py`, matching `public_views.py`.

## Test plan

- [ ] Trigger a PDF generation error — response should show `"Failed to generate PDF"` with no internal details
- [ ] Check server logs — full exception traceback should be logged there
- [ ] Verify Google OAuth with an invalid token — response should show `"Invalid token"` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in authentication and PDF generation endpoints with improved system logging for better reliability.

* **Refactor**
  * Standardized error messages across API endpoints to provide consistent user-facing responses instead of exposing technical details, improving security and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->