### PR TITLE
fix: replace coverage-badge with genbadge for CI badge generation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,8 +60,8 @@ jobs:
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         working-directory: backend
         run: |
-          pip install coverage-badge
-          coverage-badge -o ../coverage-badge.svg -f
+          pip install "genbadge[coverage]"
+          genbadge coverage -i coverage.xml -o ../coverage-badge.svg
 
       - name: Commit coverage badge
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'


### PR DESCRIPTION
## Summary
- `coverage-badge` depends on `pkg_resources` which was removed in `setuptools` 82+, causing the "Generate coverage badge" step to fail on master
- Replaced with `genbadge[coverage]` which reads from `coverage.xml` directly and has no `pkg_resources` dependency

## Test plan
- [ ] Merge to master and verify the coverage badge SVG is generated and committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline tooling for coverage badge generation to improve build process efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->