### PR TITLE
perf(rls): wrap current_setting() in the org-isolation policies so it evaluates once per statement

### DIFF
--- a/RLS_SETUP.md
+++ b/RLS_SETUP.md
@@ -229,14 +229,14 @@ Each table has two policies:
    ```sql
    CREATE POLICY org_isolation ON "lead"
        FOR ALL
-       USING (org_id::text = NULLIF(current_setting('app.current_org', true), ''));
+       USING (org_id::text = (select NULLIF(current_setting('app.current_org', true), '')));
    ```
 
 2. **Insert Check Policy**:
    ```sql
    CREATE POLICY org_insert_check ON "lead"
        FOR INSERT
-       WITH CHECK (org_id::text = NULLIF(current_setting('app.current_org', true), ''));
+       WITH CHECK (org_id::text = (select NULLIF(current_setting('app.current_org', true), '')));
    ```
 
 The `NULLIF(..., '')` ensures **no rows are returned** when context is not set (fail-safe).

--- a/backend/common/rls/__init__.py
+++ b/backend/common/rls/__init__.py
@@ -196,14 +196,14 @@ def get_enable_policy_sql(table):
         CREATE POLICY {ISOLATION_POLICY} ON "{table}"
             FOR ALL
             USING (
-                org_id::text = NULLIF(current_setting('{CONTEXT_VARIABLE}', true), '')
+                org_id::text = (select NULLIF(current_setting('{CONTEXT_VARIABLE}', true), ''))
             );
 
         -- Create insert check policy
         CREATE POLICY {INSERT_POLICY} ON "{table}"
             FOR INSERT
             WITH CHECK (
-                org_id::text = NULLIF(current_setting('{CONTEXT_VARIABLE}', true), '')
+                org_id::text = (select NULLIF(current_setting('{CONTEXT_VARIABLE}', true), ''))
             );
     """
 


### PR DESCRIPTION
## What

`get_enable_policy_sql()` in `backend/common/rls/__init__.py` stamps the tenant-isolation policy onto every RLS-enabled table, reading the org context directly in the predicate:

```sql
USING      ( org_id::text = NULLIF(current_setting('app.current_org', true), '') )
WITH CHECK ( org_id::text = NULLIF(current_setting('app.current_org', true), '') )
```

Because the `current_setting()` call sits unwrapped in the predicate, Postgres treats it as potentially row-varying and **re-evaluates it once per row scanned** — on the read/write path of every tenant table.

## Fix

Wrap the session-derived side in a scalar sub-select so the planner hoists it to a **one-time InitPlan** (once per statement, reused for every row):

```sql
USING      ( org_id::text = (select NULLIF(current_setting('app.current_org', true), '')) )
WITH CHECK ( org_id::text = (select NULLIF(current_setting('app.current_org', true), '')) )
```

Since the context is set with `set_config(..., false)` (session-scoped), the value is constant within a statement, so this is a pure planner optimization — **identical rows in, identical rows out**, N per-row GUC lookups collapse to 1. Because it's a single codegen function, every tenant table inherits the fix.

## Notes

- Two lines in the codegen (plus the matching example in `RLS_SETUP.md`, if present).
- No behavior change: the multitenancy tests assert row visibility / validation, not policy SQL text, so they're unaffected (I couldn't run the suite locally, but the change is value-preserving).
- This is the pattern Supabase [documents](https://supabase.com/docs/guides/database/postgres/row-level-security#call-functions-with-select) for session reads in RLS predicates.
- Surfaced by [pgrls](https://github.com/pgrls/pgrls) (`PERF001`), an open-source Postgres RLS linter / verifier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved row-level security policy checks for organization context handling.
  * Ensured data isolation and insert validation continue to fail safely when the organization context is unavailable.

* **Documentation**
  * Updated the row-level security setup guidance to reflect the revised policy expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->