### PR TITLE
Log missing account emails in tasks

### DIFF
--- a/backend/accounts/tasks.py
+++ b/backend/accounts/tasks.py
@@ -1,3 +1,5 @@
+import logging
+
 from celery import shared_task
 from django.conf import settings
 from django.core.mail import EmailMessage
@@ -8,12 +10,18 @@ from accounts.models import Account, AccountEmail, AccountEmailLog
 from common.models import Profile
 from common.tasks import set_rls_context
 
+logger = logging.getLogger(__name__)
+
 
 @shared_task
 def send_email(email_obj_id, org_id):
     set_rls_context(org_id)
-    email_obj = AccountEmail.objects.filter(id=email_obj_id).first()
-    if email_obj:
+    try:
+        email_obj = AccountEmail.objects.get(id=email_obj_id)
+    except AccountEmail.DoesNotExist:
+        logger.error("AccountEmail id=%s not found, skipping task.", email_obj_id)
+        return
+    else:
         from_email = email_obj.from_email
         contacts = email_obj.recipients.all()
         for contact_obj in contacts:

--- a/backend/accounts/tests/test_tasks.py
+++ b/backend/accounts/tests/test_tasks.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+
+from accounts.models import AccountEmail
+from accounts.tasks import send_email
+
+
+class SendEmailTaskTest(SimpleTestCase):
+    @patch("accounts.tasks.set_rls_context")
+    @patch("accounts.tasks.AccountEmail.objects.get")
+    def test_logs_and_returns_when_account_email_is_missing(
+        self, get_account_email, set_rls_context
+    ):
+        get_account_email.side_effect = AccountEmail.DoesNotExist
+
+        with self.assertLogs("accounts.tasks", level="ERROR") as logs:
+            result = send_email.run("missing-email", "org-id")
+
+        self.assertIsNone(result)
+        set_rls_context.assert_called_once_with("org-id")
+        get_account_email.assert_called_once_with(id="missing-email")
+        self.assertEqual(
+            logs.output,
+            [
+                "ERROR:accounts.tasks:AccountEmail id=missing-email not found, "
+                "skipping task."
+            ],
+        )


### PR DESCRIPTION
## Summary

- fetch queued account emails with `get()` instead of silently returning `None`
- log the missing email ID and stop the task when the record no longer exists
- add a focused regression test for the missing-record path

## Testing

- `uv run pytest --no-cov accounts/tests/test_tasks.py -q`
- `uvx ruff check accounts/tasks.py accounts/tests/test_tasks.py`
- `uvx ruff format --check accounts/tasks.py accounts/tests/test_tasks.py`

Fixes #678.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when an account email record is unavailable, preventing unnecessary email-processing attempts.
  * Added error logging to make missing email records easier to diagnose.
* **Tests**
  * Added coverage for missing account email scenarios and verified the task exits safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->