### PR TITLE
feat(invoices): add new template creation page and update template li…

### DIFF
--- a/backend/cases/serializer.py
+++ b/backend/cases/serializer.py
@@ -583,11 +583,16 @@ class InboundMailboxSerializer(serializers.ModelSerializer):
             )
 
     def validate_address(self, value):
-        # Postgres unique constraint already enforces (org, address); this is a
-        # nicer error than IntegrityError on the create path.
+        # Postgres enforces uniq(org, address); this is a nicer error than an
+        # IntegrityError, and it has to run on update too. When editing, the
+        # mailbox must be excluded from its own duplicate check or saving a
+        # record without changing its address would fail against itself.
         org = self.context.get("org")
-        if org and self.instance is None:
-            if InboundMailbox.objects.filter(org=org, address__iexact=value).exists():
+        if org:
+            clash = InboundMailbox.objects.filter(org=org, address__iexact=value)
+            if self.instance is not None:
+                clash = clash.exclude(pk=self.instance.pk)
+            if clash.exists():
                 raise serializers.ValidationError(
                     f"A mailbox with address {value!r} already exists for this org."
                 )

--- a/backend/cases/tests/test_inbound_email.py
+++ b/backend/cases/tests/test_inbound_email.py
@@ -619,6 +619,41 @@ class TestMailboxAPI:
         response = admin_client.get(MAILBOXES_URL)
         assert response.json()["mailboxes"] == []
 
+    def test_duplicate_address_on_update_returns_400(self, admin_client, org_a):
+        """Editing a mailbox address onto another mailbox's address is a clean
+        400, not an IntegrityError. The DB constraint is uniq(org, address);
+        before this guard the update path skipped the duplicate check entirely
+        and the constraint surfaced as a bodiless 500."""
+        first = _make_mailbox(org_a, address="support@example.com")
+        second = _make_mailbox(org_a, address="sales@example.com")
+
+        response = admin_client.put(
+            f"{MAILBOXES_URL}{second.id}/",
+            {"address": "support@example.com"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        assert "address" in response.json()["errors"]
+        second.refresh_from_db()
+        assert second.address == "sales@example.com"
+
+    def test_update_keeping_own_address_is_allowed(self, admin_client, org_a):
+        """A mailbox may be saved with its own address unchanged. The duplicate
+        guard must exclude the instance being edited or every edit that
+        resubmits the address would 400 against itself."""
+        mailbox = _make_mailbox(org_a, address="support@example.com")
+
+        response = admin_client.put(
+            f"{MAILBOXES_URL}{mailbox.id}/",
+            {"address": "support@example.com", "default_priority": "High"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        mailbox.refresh_from_db()
+        assert mailbox.address == "support@example.com"
+
 
 # ---------------------------------------------------------------------------
 # Webhook (verification path bypassed via patch)

--- a/backend/common/tests/test_users.py
+++ b/backend/common/tests/test_users.py
@@ -554,6 +554,39 @@ class TestGetTeamsAndUsersView:
         assert "teams" in response.data
         assert "profiles" in response.data
 
+    def test_permission_classes_include_has_org_context(self):
+        """Without HasOrgContext a valid JWT that carries no org_id claim leaves
+        request.profile as None and the view dereferences it, so the caller gets
+        an uncaught AttributeError 500 instead of a clean 403."""
+        from common.permissions import HasOrgContext
+        from common.views.user_views import GetTeamsAndUsersView
+
+        assert HasOrgContext in GetTeamsAndUsersView.permission_classes
+
+    def test_no_org_context_is_denied(self):
+        """The permission must be able to return False, not only True."""
+        from common.permissions import HasOrgContext
+
+        class _Request:
+            profile = None
+            org = None
+
+        assert HasOrgContext().has_permission(_Request(), None) is False
+
+    def test_org_context_present_is_allowed(self, admin_profile, org_a):
+        """The permission must be able to return True, not only False, so a
+        normal org member with an active profile and an org on the request
+        is let through."""
+        from unittest.mock import MagicMock
+
+        from common.permissions import HasOrgContext
+
+        request = MagicMock()
+        request.profile = admin_profile
+        request.profile.is_active = True
+        request.org = org_a
+        assert HasOrgContext().has_permission(request, None) is True
+
 
 @pytest.mark.django_db
 class TestProfilePrivilegeEscalation:

--- a/backend/common/views/tags_views.py
+++ b/backend/common/views/tags_views.py
@@ -68,7 +68,11 @@ def _tag_totals(org):
     return {
         "count": len(all_tags),
         "active": len(active),
-        # Active tags applied to nothing: the only ones safe to delete.
+        # Active tags applied to nothing across the models in _TAGGABLE: the
+        # "unused" figure on the settings stat card. There is no hard delete
+        # on a tag at all, here or anywhere else: TagsDetailView.delete only
+        # flips is_active to False, so this count is not measuring what is
+        # safe to remove, only what is not currently referenced.
         "unused": sum(1 for t in active if total_usage(t) == 0),
     }
 

--- a/backend/common/views/user_views.py
+++ b/backend/common/views/user_views.py
@@ -15,6 +15,7 @@ from cases.models import Case
 from cases.serializer import CaseSerializer
 from common import swagger_params
 from common.models import Comment, PersonalAccessToken, Profile, Teams, User
+from common.permissions import HasOrgContext
 from common.serializer import (
     BillingAddressSerializer,
     CommentSerializer,
@@ -51,7 +52,7 @@ def _valid_token_counts_by_profile(org):
 
 
 class GetTeamsAndUsersView(APIView):
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticated, HasOrgContext)
 
     @extend_schema(
         tags=["users"],

--- a/backend/leads/tests/test_lead_status_transitions.py
+++ b/backend/leads/tests/test_lead_status_transitions.py
@@ -140,6 +140,47 @@ class TestConvertedIsIrreversible:
 
 
 @pytest.mark.django_db
+class TestConvertOverPatchRequiresEmail:
+    """`LeadCreateSerializer.__init__` flips `email.required = True` when the
+    incoming status is `converted`, but that only runs on the PUT path.
+    `LeadDetailView.patch` has its own conversion branch that bypasses the
+    serializer entirely, so an email-less lead converted over PATCH and
+    produced an Account and an Opportunity with nobody attached."""
+
+    def test_patch_convert_without_email_is_rejected(self, admin_client, org_a):
+        lead = _lead(org_a, email="")
+
+        response = admin_client.patch(
+            _detail_url(lead.id),
+            {"status": "converted"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400
+        assert "email" in str(response.json()).lower()
+        lead.refresh_from_db()
+        assert lead.status != "converted"
+
+    def test_patch_convert_with_email_still_works(self, admin_client, org_a):
+        """The happy path must be untouched: the guard rejects only the
+        email-less case."""
+        lead = _lead(org_a, email="buyer@example.com")
+
+        response = admin_client.patch(
+            _detail_url(lead.id),
+            {"status": "converted"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["account_id"]
+        assert body["contact_id"]
+        lead.refresh_from_db()
+        assert lead.status == "converted"
+
+
+@pytest.mark.django_db
 class TestReversibleTransitionsStillWork:
     """The check has to be able to return False, not just True.
 

--- a/backend/leads/views/lead_views.py
+++ b/backend/leads/views/lead_views.py
@@ -892,6 +892,25 @@ class LeadDetailView(APIView):
                     },
                     status=status.HTTP_400_BAD_REQUEST,
                 )
+            # convert_lead_to_account only creates a Contact when the lead has
+            # an email, so converting without one yields an account and an
+            # opportunity with nobody attached. LeadCreateSerializer enforces
+            # this on the PUT path and Lead.clean() states it, but this branch
+            # runs neither: PATCH skips the serializer and a plain save() never
+            # calls full_clean().
+            if not (self.lead_obj.email or "").strip():
+                return Response(
+                    {
+                        "error": True,
+                        "errors": {
+                            "email": [
+                                "This lead needs an email address before it can be "
+                                "converted. The contact record is created from it."
+                            ]
+                        },
+                    },
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
             # Persist any custom_fields supplied alongside the conversion before
             # the converter runs, otherwise they'd be silently dropped because
             # this branch returns before the regular partial-update flow.

--- a/backend/packs/events-weddings.json
+++ b/backend/packs/events-weddings.json
@@ -182,7 +182,7 @@
         "stage": "Done", "ticket": "AV quote came back over the approved budget",
         "description": "Two screens, one operator. Signed off on the call." },
       { "title": "Chase the signed contract and the deposit", "status": "In Progress", "priority": "High", "due_date": "2026-08-06",
-        "stage": "In progress", "deal": "Whitmore & Castellanos wedding. 12 September",
+        "stage": "In progress", "deal": "Whitmore & Castellanos wedding, 12 September",
         "description": "Date is a peak Saturday and is only held until the deposit clears." },
       { "title": "Send the anniversary proposal to the family", "status": "New", "priority": "High", "due_date": "2026-08-04",
         "stage": "Scheduled", "deal": "Ferris golden anniversary dinner",

--- a/frontend/src/lib/server/v2/harness.test.js
+++ b/frontend/src/lib/server/v2/harness.test.js
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { EDITABLE_FIELDS } from '$lib/server/v2/leads.js';
+
+describe('vitest harness', () => {
+  it('resolves the $lib alias into server modules', () => {
+    expect(Array.isArray(EDITABLE_FIELDS)).toBe(true);
+    expect(EDITABLE_FIELDS).toContain('first_name');
+  });
+});

--- a/frontend/src/lib/server/v2/leads.js
+++ b/frontend/src/lib/server/v2/leads.js
@@ -524,6 +524,33 @@ export async function myProfileId(cookies) {
 }
 
 /**
+ * Convert a lead.
+ *
+ * Conversion is not a dedicated endpoint. It is a side effect of PATCHing
+ * `status: 'converted'` on the ordinary lead detail URL, which runs
+ * `convert_lead_to_account` server-side and creates an Account, a Contact when
+ * the lead has an email, and usually an Opportunity. The body carries nothing
+ * else on purpose: the backend takes no overrides for the account name, the
+ * opportunity amount, or the stage, so sending more would be silently dropped.
+ *
+ * The backend rejects a repeat conversion (`IRREVERSIBLE_STATUSES`) and, since
+ * phase 4, a conversion of a lead with no email. Both surface as a 400.
+ *
+ * @param {{ cookies: import('@sveltejs/kit').Cookies }} event
+ * @param {string} id
+ * @returns {Promise<Record<string, any>>} the raw API response, which carries
+ *   `account_id`, and `contact_id` / `opportunity_id` that may each be null.
+ */
+export async function convertLead({ cookies }, id) {
+  if (!id) throw new Error('A lead id is required to convert.');
+  return await apiRequest(
+    `/leads/${id}/`,
+    { method: 'PATCH', body: { status: 'converted' } },
+    { cookies }
+  );
+}
+
+/**
  * Everything the create form needs to render its selects, in one call.
  *
  * @param {{ cookies: import('@sveltejs/kit').Cookies }} event

--- a/frontend/src/lib/server/v2/leads.test.js
+++ b/frontend/src/lib/server/v2/leads.test.js
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const apiRequest = vi.fn();
 vi.mock('$lib/api-helpers.js', () => ({ apiRequest: (...a) => apiRequest(...a) }));
 
-const { createLead } = await import('$lib/server/v2/leads.js');
+const { createLead, convertLead } = await import('$lib/server/v2/leads.js');
 // Cast rather than shaping a full Cookies mock: createLead only ever calls
 // `cookies.get`, and `apiRequest` itself is mocked above, so nothing here
 // touches `getAll`/`set`/`delete`/`serialize`. Without the cast svelte-check
@@ -52,5 +52,41 @@ describe('createLead', () => {
     const body = apiRequest.mock.calls[0][1].body;
     expect(body.org).toBeUndefined();
     expect(body.created_by).toBeUndefined();
+  });
+});
+
+describe('convertLead', () => {
+  beforeEach(() => {
+    apiRequest.mockReset();
+  });
+
+  it('PATCHes the lead detail URL with status: converted, and nothing else', async () => {
+    apiRequest.mockResolvedValue({
+      error: false,
+      account_id: 'acc-1',
+      contact_id: 'con-1',
+      opportunity_id: 'opp-1'
+    });
+    const result = await convertLead(event, 'lead-1');
+
+    expect(apiRequest).toHaveBeenCalledOnce();
+    const [endpoint, options] = apiRequest.mock.calls[0];
+    expect(endpoint).toBe('/leads/lead-1/');
+    expect(options.method).toBe('PATCH');
+    expect(options.body).toEqual({ status: 'converted' });
+    expect(result.account_id).toBe('acc-1');
+  });
+
+  it('refuses to call the API without a lead id', async () => {
+    await expect(convertLead(event, '')).rejects.toThrow(/id is required/);
+    expect(apiRequest).not.toHaveBeenCalled();
+  });
+
+  it('lets a rejected conversion (e.g. the email guard) propagate to the caller', async () => {
+    const rejection = Object.assign(new Error('{"error":true,"errors":{"email":["required"]}}'), {
+      status: 400
+    });
+    apiRequest.mockRejectedValue(rejection);
+    await expect(convertLead(event, 'lead-1')).rejects.toBe(rejection);
   });
 });

--- a/frontend/src/lib/server/v2/recurring.js
+++ b/frontend/src/lib/server/v2/recurring.js
@@ -14,12 +14,12 @@
  * (a `get_recurring_or_error` mirroring the estimate one, plus list scoping);
  * this page is the client that finally draws the writes those endpoints guard.
  *
- * THE ONE WRITE: PAUSE / RESUME
+ * THE ONE WRITE, THEN THE SECOND
  * The page's thesis is "does anyone have to do anything"; `auto_send`, and
- * whether a schedule is live or paused. Pause/resume is the one action that
- * belongs on a schedule worklist, so it is wired here (`toggle`) and everything
- * else (creating a schedule, a builder with line items and FK pickers) is
- * deferred, the same class of surface as the invoice builder (#48).
+ * whether a schedule is live or paused. Pause/resume was the first write, next
+ * to the state it changes (`toggle`). Creating a schedule is the second: a
+ * builder with line items and three FK pickers, the same shape as the invoice
+ * builder (#48), and it lives here as `createRecurringInvoice`.
  *
  * TOTALS ARE COMPUTED HERE
  * The list endpoint has no `totals` envelope. The four header figures are
@@ -165,4 +165,113 @@ export async function listRecurringInvoices({ cookies }) {
  */
 export async function toggleRecurring({ cookies }, id) {
   return apiRequest(`/invoices/recurring/${id}/toggle/`, { method: 'POST', body: {} }, { cookies });
+}
+
+/**
+ * Every field `RecurringInvoiceCreateSerializer` accepts. Anything not on this
+ * list never reaches the API, which is what keeps a forged `org`, `created_by`,
+ * or a hand-set `total_amount` out of the body. Totals are recalculated
+ * server-side on every create and update, and `org` comes from the JWT.
+ */
+export const CREATE_FIELDS = [
+  'account_id',
+  'contact_id',
+  'opportunity_id',
+  'title',
+  'is_active',
+  'client_name',
+  'client_email',
+  'frequency',
+  'custom_days',
+  'start_date',
+  'end_date',
+  'next_generation_date',
+  'payment_terms',
+  'auto_send',
+  'currency',
+  'discount_type',
+  'discount_value',
+  'tax_rate',
+  'notes',
+  'terms',
+  'line_items'
+];
+
+/**
+ * Copy only allow-listed keys. `undefined` is skipped rather than anything
+ * falsy, so an explicit empty string still travels and can clear a field, while
+ * a key the form never rendered stays absent. An empty `line_items` array is
+ * dropped: the serializer treats the field as optional and sending `[]` would
+ * be an explicit "no lines" write rather than "not specified".
+ *
+ * The allow-list applies to TOP-LEVEL keys only. `line_items` is copied through
+ * as-is, so an extra key inside a line-item object is not stripped here. That is
+ * safe because `RecurringInvoiceLineItemCreateSerializer` declares its own
+ * explicit field list and DRF drops anything else during nested
+ * `to_internal_value`, which is the check that actually matters. Stated plainly
+ * so nobody reads this function as a deeper guarantee than it gives.
+ *
+ * @param {string[]} allowed
+ * @param {Record<string, any>} values
+ * @returns {Record<string, any>}
+ */
+export function buildBody(allowed, values) {
+  /** @type {Record<string, any>} */
+  const body = {};
+  for (const key of allowed) {
+    const value = values[key];
+    if (value === undefined) continue;
+    if (key === 'line_items') {
+      if (Array.isArray(value) && value.length > 0) body[key] = value;
+      continue;
+    }
+    body[key] = value;
+  }
+  return body;
+}
+
+/**
+ * Create a recurring schedule.
+ *
+ * `POST /invoices/recurring/` has `permission_classes = (IsAuthenticated,
+ * HasOrgContext)` and no role gate, so any org member may create one. Do not
+ * hide the control behind an admin check: that would be a UX regression, not a
+ * security improvement, and the backend is the boundary either way.
+ *
+ * The four guards below are fast fails for obvious mistakes. Three mirror real
+ * server rules: `account_id` and `contact_id` are required by
+ * `RecurringInvoiceCreateSerializer` (and it also cross-checks that the
+ * contact belongs to the account), and `title` is required because
+ * `RecurringInvoice.title` is a `CharField(max_length=100)` with no
+ * `blank=True`, so DRF makes it required and non-blank there too. The
+ * `custom_days` guard does not mirror anything: the serializer has no
+ * cross-validation between `frequency` and `custom_days`, so a CUSTOM schedule
+ * with no interval is accepted server-side and then silently generates monthly
+ * via `calculate_next_date()`. That is a backend gap; this check keeps the form
+ * from walking into it.
+ *
+ * `RecurringInvoiceListView.post` (`backend/invoices/api_views.py`) wraps its
+ * result in an envelope, `{ error, message, recurring_invoice }`, exactly the
+ * trap `createTag` documents in `tags.js`: a `create*` function that resolves
+ * to the envelope instead of the record is the one the next caller reaches
+ * for `.id` on and gets `undefined`. This unwraps to `.recurring_invoice`
+ * deliberately, with the same `?? resp` fallback as `createTag`, so a change
+ * in the backend's response shape degrades to the raw envelope rather than
+ * throwing.
+ *
+ * @param {{ cookies: import('@sveltejs/kit').Cookies }} event
+ * @param {Record<string, any>} values
+ * @returns {Promise<any>}
+ */
+export async function createRecurringInvoice({ cookies }, values) {
+  if (!values.account_id) throw new Error('Choose an account.');
+  if (!values.contact_id) throw new Error('Choose a contact.');
+  if (!(values.title ?? '').toString().trim()) throw new Error('Give the schedule a title.');
+  if (values.frequency === 'CUSTOM' && !values.custom_days) {
+    throw new Error('A custom frequency needs an interval in days.');
+  }
+
+  const body = buildBody(CREATE_FIELDS, values);
+  const resp = await apiRequest('/invoices/recurring/', { method: 'POST', body }, { cookies });
+  return resp.recurring_invoice ?? resp;
 }

--- a/frontend/src/lib/server/v2/recurring.test.js
+++ b/frontend/src/lib/server/v2/recurring.test.js
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const apiRequest = vi.fn();
+vi.mock('$lib/api-helpers.js', () => ({
+  apiRequest: (/** @type {any[]} */ ...args) => apiRequest(...args)
+}));
+
+const { createRecurringInvoice } = await import('./recurring.js');
+
+const cookies = /** @type {any} */ ({});
+
+describe('createRecurringInvoice', () => {
+  beforeEach(() => {
+    apiRequest.mockReset();
+    apiRequest.mockResolvedValue({ id: 'r1' });
+  });
+
+  it('posts to the recurring collection', async () => {
+    await createRecurringInvoice(
+      { cookies },
+      { account_id: 'a1', contact_id: 'c1', title: 'Monthly retainer' }
+    );
+    const [url, options] = apiRequest.mock.calls[0];
+    expect(url).toBe('/invoices/recurring/');
+    expect(options.method).toBe('POST');
+  });
+
+  it('drops server-derived keys a caller tries to set', async () => {
+    await createRecurringInvoice(
+      { cookies },
+      {
+        account_id: 'a1',
+        contact_id: 'c1',
+        title: 'Retainer',
+        org: 'attacker-org',
+        created_by: 'someone-else',
+        total_amount: '999999',
+        invoices_generated: 42,
+        id: 'forged'
+      }
+    );
+    const [, options] = apiRequest.mock.calls[0];
+    expect(options.body.org).toBeUndefined();
+    expect(options.body.created_by).toBeUndefined();
+    expect(options.body.total_amount).toBeUndefined();
+    expect(options.body.invoices_generated).toBeUndefined();
+    expect(options.body.id).toBeUndefined();
+  });
+
+  it('requires an account and a contact', async () => {
+    await expect(
+      createRecurringInvoice({ cookies }, { contact_id: 'c1', title: 'x' })
+    ).rejects.toThrow();
+    await expect(
+      createRecurringInvoice({ cookies }, { account_id: 'a1', title: 'x' })
+    ).rejects.toThrow();
+    expect(apiRequest).not.toHaveBeenCalled();
+  });
+
+  it('requires a title', async () => {
+    await expect(
+      createRecurringInvoice({ cookies }, { account_id: 'a1', contact_id: 'c1', title: '   ' })
+    ).rejects.toThrow();
+    expect(apiRequest).not.toHaveBeenCalled();
+  });
+
+  it('requires custom_days when the frequency is CUSTOM, which the server does not', async () => {
+    await expect(
+      createRecurringInvoice(
+        { cookies },
+        { account_id: 'a1', contact_id: 'c1', title: 'x', frequency: 'CUSTOM' }
+      )
+    ).rejects.toThrow();
+    expect(apiRequest).not.toHaveBeenCalled();
+  });
+
+  it('accepts CUSTOM with custom_days', async () => {
+    await createRecurringInvoice(
+      { cookies },
+      { account_id: 'a1', contact_id: 'c1', title: 'x', frequency: 'CUSTOM', custom_days: 45 }
+    );
+    const [, options] = apiRequest.mock.calls[0];
+    expect(options.body.custom_days).toBe(45);
+  });
+
+  it('omits line_items entirely when none are given, rather than sending an empty array', async () => {
+    await createRecurringInvoice(
+      { cookies },
+      { account_id: 'a1', contact_id: 'c1', title: 'x', line_items: [] }
+    );
+    const [, options] = apiRequest.mock.calls[0];
+    expect(options.body.line_items).toBeUndefined();
+  });
+
+  it('keeps an explicit empty string, so a field can be cleared', async () => {
+    await createRecurringInvoice(
+      { cookies },
+      { account_id: 'a1', contact_id: 'c1', title: 'x', notes: '' }
+    );
+    const [, options] = apiRequest.mock.calls[0];
+    expect(options.body.notes).toBe('');
+  });
+
+  it('unwraps the created schedule from the envelope', async () => {
+    apiRequest.mockResolvedValue({
+      error: false,
+      message: 'Recurring invoice created',
+      recurring_invoice: { id: 'r1', title: 'Monthly retainer' }
+    });
+    const result = await createRecurringInvoice(
+      { cookies },
+      { account_id: 'a1', contact_id: 'c1', title: 'Monthly retainer' }
+    );
+    expect(result).toEqual({ id: 'r1', title: 'Monthly retainer' });
+  });
+
+  it('falls back to the raw response if it has no recurring_invoice envelope', async () => {
+    apiRequest.mockResolvedValue({ id: 'r1', title: 'Monthly retainer' });
+    const result = await createRecurringInvoice(
+      { cookies },
+      { account_id: 'a1', contact_id: 'c1', title: 'Monthly retainer' }
+    );
+    expect(result).toEqual({ id: 'r1', title: 'Monthly retainer' });
+  });
+});

--- a/frontend/src/lib/server/v2/tags.js
+++ b/frontend/src/lib/server/v2/tags.js
@@ -9,8 +9,9 @@
  * (the usage counts are org-scoped subqueries, not a client tally over rows).
  *
  * "New tag" is wired: `createTag` below posts the name and the page's action
- * calls it. The duplicate-merge banner is still deferred; its "Merge" button
- * has no backing endpoint yet, see the comment on it in `+page.svelte`.
+ * calls it. Turning a tag off and back on are wired too, through `archiveTag`
+ * and `restoreTag`. The duplicate-merge banner is still deferred; its "Merge"
+ * button has no backing endpoint yet, see the comment on it in `+page.svelte`.
  *
  * CREATE IS ADMIN-ONLY, LIST IS NOT
  * `/settings` is deliberately member-readable (see the comment in
@@ -81,4 +82,46 @@ export async function createTag({ cookies }, values) {
 
   const resp = await apiRequest('/tags/', { method: 'POST', body: { name } }, { cookies });
   return resp.tag ?? resp;
+}
+
+/**
+ * Archive a tag.
+ *
+ * This is a soft delete and the copy around it must say so. `TagsDetailView`
+ * sets `is_active = False`, saves, and returns 200 with
+ * `{ error: false, message: 'Tag archived successfully' }`. It never calls
+ * `.delete()`, no hard-delete path is exposed anywhere, and every relationship
+ * to a tag from a taggable model is a ManyToManyField, so nothing is cascaded
+ * or protected. The rows that carry the tag keep it; the tag simply stops being
+ * offered. `restoreTag` puts it back.
+ *
+ * Admin-only on the backend, 403 otherwise. The page hides the control for a
+ * member using the `can_edit` hint from `getTags`, but that hint is decoded
+ * from the JWT and is display only; the backend re-derives the role and is the
+ * check that matters.
+ *
+ * No body is sent: the tag is identified by the URL and the backend derives
+ * org and actor from the token.
+ *
+ * @param {{ cookies: import('@sveltejs/kit').Cookies }} event
+ * @param {string} id
+ * @returns {Promise<any>}
+ */
+export async function archiveTag({ cookies }, id) {
+  if (!id) throw new Error('A tag id is required to turn a tag off.');
+  return await apiRequest(`/tags/${id}/`, { method: 'DELETE' }, { cookies });
+}
+
+/**
+ * Restore an archived tag: sets `is_active = True` again. Admin-only, 200 on
+ * success. The list already includes archived tags (`?include_archived=true`),
+ * so a restored tag needs no separate fetch to become visible.
+ *
+ * @param {{ cookies: import('@sveltejs/kit').Cookies }} event
+ * @param {string} id
+ * @returns {Promise<any>}
+ */
+export async function restoreTag({ cookies }, id) {
+  if (!id) throw new Error('A tag id is required to turn a tag back on.');
+  return await apiRequest(`/tags/${id}/restore/`, { method: 'POST' }, { cookies });
 }

--- a/frontend/src/lib/server/v2/tags.test.js
+++ b/frontend/src/lib/server/v2/tags.test.js
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const apiRequest = vi.fn();
 vi.mock('$lib/api-helpers.js', () => ({ apiRequest: (...a) => apiRequest(...a) }));
 
-const { createTag } = await import('$lib/server/v2/tags.js');
+const { createTag, archiveTag, restoreTag } = await import('$lib/server/v2/tags.js');
 // Cast rather than shaping a full Cookies mock, matching leads.test.js:
 // createTag only ever calls `cookies.get`, and `apiRequest` itself is mocked
 // above, so nothing here touches `getAll`/`set`/`delete`/`serialize`. Without
@@ -52,5 +52,53 @@ describe('createTag', () => {
     apiRequest.mockResolvedValue({ tag: { id: 't1' } });
     await createTag(event, { name: 'urgent', org: 'attacker-org' });
     expect(apiRequest.mock.calls[0][1].body.org).toBeUndefined();
+  });
+});
+
+describe('archiveTag', () => {
+  beforeEach(() => {
+    apiRequest.mockReset();
+  });
+
+  it('sends DELETE to the tag detail url', async () => {
+    // The backend soft-archives on DELETE: it sets is_active = False and
+    // returns 200 with this envelope. It never removes the row.
+    apiRequest.mockResolvedValue({ error: false, message: 'Tag archived successfully' });
+    await archiveTag(event, 'tag-1');
+    const [endpoint, options] = apiRequest.mock.calls[0];
+    expect(endpoint).toBe('/tags/tag-1/');
+    expect(options.method).toBe('DELETE');
+  });
+
+  it('refuses an empty id rather than calling the collection url', async () => {
+    // Without this guard the url collapses to `/tags//`, and a caller that
+    // lost the id would be aiming an unscoped request at the collection.
+    await expect(archiveTag(event, '')).rejects.toThrow(/id/i);
+    expect(apiRequest).not.toHaveBeenCalled();
+  });
+
+  it('sends no request body, because the backend derives everything', async () => {
+    apiRequest.mockResolvedValue({ error: false });
+    await archiveTag(event, 'tag-1');
+    expect(apiRequest.mock.calls[0][1].body).toBeUndefined();
+  });
+});
+
+describe('restoreTag', () => {
+  beforeEach(() => {
+    apiRequest.mockReset();
+  });
+
+  it('posts to the restore url', async () => {
+    apiRequest.mockResolvedValue({ error: false });
+    await restoreTag(event, 'tag-1');
+    const [endpoint, options] = apiRequest.mock.calls[0];
+    expect(endpoint).toBe('/tags/tag-1/restore/');
+    expect(options.method).toBe('POST');
+  });
+
+  it('refuses an empty id', async () => {
+    await expect(restoreTag(event, '')).rejects.toThrow(/id/i);
+    expect(apiRequest).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/lib/server/v2/templates.js
+++ b/frontend/src/lib/server/v2/templates.js
@@ -21,12 +21,16 @@
  * that stops the WeasyPrint SSRF/local-file-read); this page is the client that
  * draws the one write a worklist should own.
  *
- * THE ONE WRITE: SET DEFAULT
+ * THE ONE WRITE: SET DEFAULT, THEN A SECOND: CREATE
  * `is_default` is a singleton, the model clears it on every other row inside a
- * transaction, so making a template the default is a swap, not a toggle. That
- * is the action wired here. Creating or editing a template is a full builder
- * (colours, logo upload, and the raw markup), the same class of deferred
- * surface as the invoice builder (#48); it is not wired in this pass.
+ * transaction, so making a template the default is a swap, not a toggle.
+ * Creating a template is the second write, `createInvoiceTemplate` below.
+ * Editing one stays out of scope: the detail GET uses the same stripping
+ * serializer as the list, so an edit form could never pre-fill the raw markup,
+ * and that gap is left as an honest, disabled control rather than a silent
+ * dead button (see the list page). `template_html` / `template_css` are also
+ * left out of the create form on purpose, for the same reason: see
+ * `CREATE_FIELDS` below.
  *
  * TOTALS ARE COMPUTED HERE
  * The list endpoint has no `totals` envelope. `count` comes from the response;
@@ -112,4 +116,104 @@ export async function setDefaultTemplate({ cookies }, id) {
     { method: 'PUT', body: { is_default: true } },
     { cookies }
   );
+}
+
+const HEX_COLOR = /^#[0-9a-fA-F]{6}$/;
+
+/**
+ * Every field this form is allowed to write.
+ *
+ * `template_html` and `template_css` are deliberately absent even though
+ * `InvoiceTemplateCreateSerializer` accepts them. Every read serializer strips
+ * them on purpose and substitutes `has_custom_html` / `has_custom_css` /
+ * `custom_html_bytes`, and the detail GET uses that same stripping serializer,
+ * so a value written here could never be read back or edited afterwards. It
+ * also feeds the WeasyPrint PDF renderer. A write-once, never-readable markup
+ * field is a trap, so this form does not offer one. Never render either value
+ * with `{@html}`.
+ */
+export const CREATE_FIELDS = [
+  'name',
+  'primary_color',
+  'secondary_color',
+  'default_notes',
+  'default_terms',
+  'footer_text',
+  'is_default'
+];
+
+/**
+ * Create an invoice template.
+ *
+ * Admin-only server-side: `_forbid_non_admin_template_write` 403s anyone whose
+ * `profile.role` is not ADMIN and who is not a superuser. The page hides the
+ * control using `can_manage`, but that is a display hint decoded from the JWT;
+ * the backend re-derives the role and is the check that matters.
+ *
+ * The colour checks below mirror nothing on the server. Neither colour field
+ * has a format validator; the model is `max_length=7` only, so `"purple"` is
+ * stored happily and then renders as an invalid CSS colour in the PDF. That is
+ * a backend gap, flagged rather than worked around.
+ *
+ * `is_default` is not a plain field write: the model's `save()` clears the flag
+ * on every other template in the org inside a transaction, so setting it here
+ * demotes whichever template is currently default.
+ *
+ * When a logo is supplied the body must be multipart, because `logo` is an
+ * ImageField. `apiRequest` already detects a `FormData` body and leaves
+ * `Content-Type` unset so the browser adds the boundary.
+ *
+ * `InvoiceTemplateListView.post` (`backend/invoices/api_views.py`) wraps its
+ * result in an envelope, `{ error, message, template }`, exactly the trap
+ * `createTag` documents in `tags.js`: a `create*` function that resolves to
+ * the envelope instead of the record is the one the next caller reaches for
+ * `.id` on and gets `undefined`. This unwraps to `.template` deliberately,
+ * with the same `?? resp` fallback as `createTag`, so a change in the
+ * backend's response shape degrades to the raw envelope rather than throwing.
+ *
+ * @param {{ cookies: import('@sveltejs/kit').Cookies }} event
+ * @param {Record<string, any>} values
+ * @param {File | null} [logoFile]
+ * @returns {Promise<any>}
+ */
+export async function createInvoiceTemplate({ cookies }, values, logoFile = null) {
+  const name = (values.name ?? '').toString().trim();
+  if (!name) throw new Error('Give the template a name.');
+
+  for (const key of ['primary_color', 'secondary_color']) {
+    const colour = values[key];
+    if (colour !== undefined && colour !== '' && !HEX_COLOR.test(String(colour))) {
+      throw new Error('Colours must be a six digit hex value, for example #3B82F6.');
+    }
+  }
+
+  /** @type {Record<string, any>} */
+  const fields = {};
+  for (const key of CREATE_FIELDS) {
+    if (values[key] === undefined) continue;
+    // An empty colour is omitted rather than sent as `''`. The model has no
+    // `blank=True` on either colour, so DRF would answer a literal empty string
+    // with "This field may not be blank", while omitting the key lets the model
+    // default apply. Only reachable if `input type="color"` degrades to a text
+    // field, but the failure would be a raw 400 with no useful message.
+    if ((key === 'primary_color' || key === 'secondary_color') && values[key] === '') continue;
+    fields[key] = key === 'name' ? name : values[key];
+  }
+
+  if (logoFile) {
+    const body = new FormData();
+    for (const [key, value] of Object.entries(fields)) {
+      body.append(key, typeof value === 'boolean' ? String(value) : value);
+    }
+    body.append('logo', logoFile);
+    const resp = await apiRequest('/invoices/templates/', { method: 'POST', body }, { cookies });
+    return resp.template ?? resp;
+  }
+
+  const resp = await apiRequest(
+    '/invoices/templates/',
+    { method: 'POST', body: fields },
+    { cookies }
+  );
+  return resp.template ?? resp;
 }

--- a/frontend/src/lib/server/v2/templates.test.js
+++ b/frontend/src/lib/server/v2/templates.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const apiRequest = vi.fn();
+vi.mock('$lib/api-helpers.js', () => ({
+  apiRequest: (/** @type {any[]} */ ...args) => apiRequest(...args)
+}));
+
+const { createInvoiceTemplate, CREATE_FIELDS } = await import('./templates.js');
+
+const cookies = /** @type {any} */ ({});
+
+describe('createInvoiceTemplate', () => {
+  beforeEach(() => {
+    apiRequest.mockReset();
+    apiRequest.mockResolvedValue({ id: 't1' });
+  });
+
+  it('never accepts the raw markup fields', () => {
+    expect(CREATE_FIELDS).not.toContain('template_html');
+    expect(CREATE_FIELDS).not.toContain('template_css');
+  });
+
+  it('posts to the templates collection', async () => {
+    await createInvoiceTemplate({ cookies }, { name: 'Clean' });
+    const [url, options] = apiRequest.mock.calls[0];
+    expect(url).toBe('/invoices/templates/');
+    expect(options.method).toBe('POST');
+  });
+
+  it('drops the markup fields even when a caller forces them in', async () => {
+    await createInvoiceTemplate(
+      { cookies },
+      { name: 'Clean', template_html: '<script>x</script>', template_css: 'body{}' }
+    );
+    const [, options] = apiRequest.mock.calls[0];
+    const sent = options.body;
+    expect(sent.template_html).toBeUndefined();
+    expect(sent.template_css).toBeUndefined();
+  });
+
+  it('drops server-derived keys', async () => {
+    await createInvoiceTemplate({ cookies }, { name: 'Clean', org: 'attacker-org', id: 'forged' });
+    const [, options] = apiRequest.mock.calls[0];
+    expect(options.body.org).toBeUndefined();
+    expect(options.body.id).toBeUndefined();
+  });
+
+  it('requires a name', async () => {
+    await expect(createInvoiceTemplate({ cookies }, { name: '  ' })).rejects.toThrow();
+    expect(apiRequest).not.toHaveBeenCalled();
+  });
+
+  it('rejects a colour that is not a hex value, which the server does not check', async () => {
+    await expect(
+      createInvoiceTemplate({ cookies }, { name: 'Clean', primary_color: 'purple' })
+    ).rejects.toThrow();
+    await expect(
+      createInvoiceTemplate({ cookies }, { name: 'Clean', secondary_color: '#12' })
+    ).rejects.toThrow();
+    expect(apiRequest).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid hex colour', async () => {
+    await createInvoiceTemplate(
+      { cookies },
+      { name: 'Clean', primary_color: '#3B82F6', secondary_color: '#1e40af' }
+    );
+    expect(apiRequest).toHaveBeenCalled();
+  });
+
+  it('omits an empty colour rather than sending it as an empty string', async () => {
+    // Neither colour field has `blank=True` on the model, so a literal `''`
+    // earns a raw 400 ("This field may not be blank"). Omitting the key lets
+    // the model default apply instead.
+    await createInvoiceTemplate(
+      { cookies },
+      { name: 'Clean', primary_color: '', secondary_color: '#1e40af' }
+    );
+    const [, options] = apiRequest.mock.calls[0];
+    expect(options.body.primary_color).toBeUndefined();
+    expect(options.body.secondary_color).toBe('#1e40af');
+  });
+
+  it('sends FormData when a logo file is supplied', async () => {
+    const file = new File(['x'], 'logo.png', { type: 'image/png' });
+    await createInvoiceTemplate({ cookies }, { name: 'Clean' }, file);
+    const [, options] = apiRequest.mock.calls[0];
+    expect(options.body).toBeInstanceOf(FormData);
+    expect(options.body.get('name')).toBe('Clean');
+    expect(options.body.get('logo')).toBe(file);
+  });
+
+  it('sends a plain object when there is no logo', async () => {
+    await createInvoiceTemplate({ cookies }, { name: 'Clean' });
+    const [, options] = apiRequest.mock.calls[0];
+    expect(options.body).not.toBeInstanceOf(FormData);
+    expect(options.body.name).toBe('Clean');
+  });
+
+  it('unwraps the created template from the envelope', async () => {
+    apiRequest.mockResolvedValue({
+      error: false,
+      message: 'Template created',
+      template: { id: 't1', name: 'Clean' }
+    });
+    const result = await createInvoiceTemplate({ cookies }, { name: 'Clean' });
+    expect(result).toEqual({ id: 't1', name: 'Clean' });
+  });
+
+  it('falls back to the raw response if it has no template envelope', async () => {
+    apiRequest.mockResolvedValue({ id: 't1', name: 'Clean' });
+    const result = await createInvoiceTemplate({ cookies }, { name: 'Clean' });
+    expect(result).toEqual({ id: 't1', name: 'Clean' });
+  });
+});

--- a/frontend/src/routes/(app)/invoices/recurring/+page.svelte
+++ b/frontend/src/routes/(app)/invoices/recurring/+page.svelte
@@ -53,10 +53,7 @@
     <span class="v2-num">{money(totals.monthly_run_rate)}</span> a month
   {/snippet}
   {#snippet actions()}
-    <!-- Creating a schedule is a builder (line items + FK pickers), the same
-         class as the invoice builder (#48); it stays deferred, so this button
-         is intentionally inert for now rather than pointed at a half-built form. -->
-    <button class="v2-btn v2-btn-primary"><Plus />New schedule</button>
+    <a class="v2-btn v2-btn-primary" href="/invoices/recurring/new"><Plus />New schedule</a>
   {/snippet}
 </PageHeader>
 
@@ -96,7 +93,9 @@
       body="A recurring invoice is a template plus a cadence. Set one up for anything you bill on the same day every month and stop retyping it."
     >
       {#snippet icon()}<RefreshCw size={21} />{/snippet}
-      {#snippet actions()}<button class="v2-btn v2-btn-primary">New schedule</button>{/snippet}
+      {#snippet actions()}
+        <a class="v2-btn v2-btn-primary" href="/invoices/recurring/new">New schedule</a>
+      {/snippet}
     </EmptyState>
   {:else}
     <div class="v2-table-wrap">

--- a/frontend/src/routes/(app)/invoices/recurring/new/+page.server.js
+++ b/frontend/src/routes/(app)/invoices/recurring/new/+page.server.js
@@ -1,0 +1,66 @@
+import { fail, redirect } from '@sveltejs/kit';
+import { listAccounts } from '$lib/server/v2/accounts.js';
+import { listContacts } from '$lib/server/v2/contacts.js';
+import { listProducts } from '$lib/server/v2/products.js';
+import { createRecurringInvoice } from '$lib/server/v2/recurring.js';
+import { readableError } from '$lib/server/v2/form-errors.js';
+
+/**
+ * Same three pickers as the one-off invoice builder: account and contact are
+ * both required by the serializer, which also cross-checks that the contact
+ * belongs to the chosen account, and the product catalogue feeds the line-item
+ * rows. Contacts carry their account so the page can offer only the ones that
+ * pass that rule.
+ *
+ * @type {import('./$types').PageServerLoad}
+ */
+export async function load({ cookies }) {
+  const [accounts, contacts, products] = await Promise.all([
+    listAccounts({ cookies }, new URLSearchParams({ limit: '1000' })),
+    listContacts({ cookies }, new URLSearchParams({ limit: '1000' })),
+    listProducts({ cookies })
+  ]);
+
+  return {
+    accounts: accounts.results.map((a) => ({ id: a.id, name: a.name || 'Unnamed account' })),
+    contacts: contacts.results.map((c) => ({
+      id: c.id,
+      name: c.name || c.email || 'Unnamed contact',
+      account_id: c.account?.id ?? null,
+      account_name: c.account?.name ?? ''
+    })),
+    products: products.results
+      .filter((p) => p.is_active)
+      .map((p) => ({ id: p.id, name: p.name, sku: p.sku, price: p.price }))
+  };
+}
+
+/** @type {import('./$types').Actions} */
+export const actions = {
+  /**
+   * Create the schedule. The page serialises the whole builder into one
+   * `payload` field so the dynamic line-item list travels intact; the server
+   * owns org, totals and invoices_generated. There is no per-schedule detail
+   * route (`invoices/recurring/[id]/` does not exist), so on success we land
+   * back on the schedules list rather than inventing a redirect target.
+   */
+  create: async ({ cookies, request }) => {
+    const form = await request.formData();
+    let values;
+    try {
+      values = JSON.parse(form.get('payload')?.toString() || '{}');
+    } catch {
+      return fail(400, { error: 'The schedule form could not be read. Please try again.' });
+    }
+
+    try {
+      await createRecurringInvoice({ cookies }, values);
+    } catch (/** @type {any} */ err) {
+      return fail(err?.status === 403 ? 403 : 400, {
+        error: readableError(err, 'Could not create the schedule.')
+      });
+    }
+
+    redirect(303, '/invoices/recurring');
+  }
+};

--- a/frontend/src/routes/(app)/invoices/recurring/new/+page.svelte
+++ b/frontend/src/routes/(app)/invoices/recurring/new/+page.svelte
@@ -1,0 +1,648 @@
+<script>
+  /**
+   * New recurring schedule.
+   *
+   * Same shape as the one-off invoice builder (`invoices/new`): three FK
+   * pickers, an optional line-item list, and the whole form serialised into one
+   * hidden `payload` field so the dynamic list survives the POST intact. Reused
+   * directly: the account/contact filtering rule and the line-item row markup.
+   *
+   * WHAT IS DIFFERENT FROM THE INVOICE BUILDER
+   * A schedule has no line-item requirement: `RecurringInvoiceCreateSerializer`
+   * lists `line_items` as optional, because a schedule can exist before anyone
+   * has priced it out, so `ready` below never checks `usableLines.length`.
+   *
+   * `org`, `created_by`, `subtotal`, `total_amount` and `invoices_generated` are
+   * absent for the same reason they are absent from the invoice builder: they
+   * are server-derived, and a form that collects them is a form that can be
+   * edited to claim them.
+   *
+   * NO ROLE GATE
+   * `POST /invoices/recurring/` has `permission_classes = (IsAuthenticated,
+   * HasOrgContext)`, no admin check, unlike invoice templates. Nothing on this
+   * page is conditioned on `role`.
+   *
+   * THE ONE GUARD THE SERVER DOES NOT HAVE
+   * `RecurringInvoiceCreateSerializer` never cross-validates `frequency` against
+   * `custom_days`; a CUSTOM schedule with no interval is accepted and then
+   * silently generates monthly. `ready` below requires `customDays` whenever
+   * CUSTOM is chosen so the form does not walk into that gap, but this is a UX
+   * guard over a real backend gap, not a mirror of a server rule.
+   */
+  import { enhance } from '$app/forms';
+  import PageHeader from '$lib/v2/components/PageHeader.svelte';
+  import SectionTabs from '$lib/v2/components/SectionTabs.svelte';
+  import PortalLineItems from '$lib/v2/components/PortalLineItems.svelte';
+  import { RECURRING_FREQUENCY_LABEL, PAYMENT_TERMS_LABEL } from '$lib/v2/enums.js';
+  import { money } from '$lib/v2/format.js';
+  import { Plus, Trash2 } from '@lucide/svelte';
+
+  /** @type {{ data: { products: any[], accounts: any[], contacts: any[] }, form: any }} */
+  let { data, form } = $props();
+
+  const today = new Date().toISOString().slice(0, 10);
+
+  /**
+   * The currency codes `RecurringInvoice.currency` accepts (`common.utils.
+   * CURRENCY_CODES`), the same set `$lib/server/v2/products.js` offers for the
+   * catalogue. Repeated here rather than imported: a `.svelte` file cannot
+   * import from `$lib/server/`, and this module has no other reason to share a
+   * constant with the page, so it is not worth moving into `enums.js`.
+   */
+  // All 13 codes the backend accepts (`CURRENCY_CODES` in `common/utils.py`),
+  // not a subset. Offering fewer would leave an org that bills in one of the
+  // missing ones unable to create a schedule at all, for no reason.
+  const CURRENCIES = [
+    'USD',
+    'EUR',
+    'GBP',
+    'INR',
+    'CAD',
+    'AUD',
+    'JPY',
+    'CNY',
+    'CHF',
+    'SGD',
+    'AED',
+    'BRL',
+    'MXN'
+  ];
+
+  let accountId = $state('');
+  let contactId = $state('');
+  let title = $state('');
+  let frequency = $state('MONTHLY');
+  let customDays = $state('');
+  let paymentTerms = $state('NET_30');
+  let currency = $state('USD');
+  let startDate = $state(today);
+  let endDate = $state('');
+  let nextGenerationDate = $state(today);
+  let autoSend = $state(false);
+  let discountType = $state('');
+  let discountValue = $state(0);
+  let taxRate = $state(0);
+  let notes = $state('');
+  let terms = $state('');
+
+  let items = $state([{ name: '', description: '', quantity: 1, unit_price: 0, product: null }]);
+
+  /**
+   * Contacts whose primary account is this account, plus contacts with no
+   * account (they attach to anyone).
+   *
+   * `c.account_id` (set in `+page.server.js` from `contacts.js`'s
+   * `accountLink`) is the primary FK when the contact has one, and the first
+   * M2M membership otherwise. The server's cross-check,
+   * `RecurringInvoiceCreateSerializer.validate` (`invoices/serializer.py:
+   * 1182-1193`), looks only at the real primary FK, `contact.account_id`, and
+   * only rejects when that FK is set and differs from the chosen account: a
+   * contact with no primary FK passes there for any account. So this filter
+   * is deliberately stricter than the server, not a mirror of it: it can hide
+   * a pairing the API would accept for a contact whose primary FK is unset
+   * and whose first M2M membership is some other account. That is the safer
+   * direction to be wrong in for a picker: under-offer rather than walk
+   * someone into a 400.
+   */
+  let contactOptions = $derived(
+    data.contacts.filter((c) => !c.account_id || c.account_id === accountId)
+  );
+
+  const num = (v) => (Number.isFinite(Number(v)) ? Number(v) : 0);
+
+  /** Per-line total, matching RecurringInvoiceLineItem: quantity x unit_price. */
+  let lines = $derived(items.map((i) => ({ ...i, total: num(i.quantity) * num(i.unit_price) })));
+
+  /* The same ladder the serializer's _recalculate_totals runs, in order. There
+     is no shipping field on a recurring schedule, unlike the one-off invoice. */
+  let subtotal = $derived(lines.reduce((a, l) => a + l.total, 0));
+  let discountAmount = $derived(
+    discountType === 'PERCENTAGE'
+      ? subtotal * (num(discountValue) / 100)
+      : discountType === 'FIXED'
+        ? num(discountValue)
+        : 0
+  );
+  let taxable = $derived(subtotal - discountAmount);
+  let taxAmount = $derived(taxable * (num(taxRate) / 100));
+  let total = $derived(taxable + taxAmount);
+
+  /** A line with a name and a positive amount is a line worth billing. */
+  let usableLines = $derived(lines.filter((l) => l.name.trim() && l.total > 0));
+
+  /** Line items are optional on a schedule, so this never checks their count. */
+  let ready = $derived(
+    Boolean(accountId) &&
+      Boolean(contactId) &&
+      Boolean(title.trim()) &&
+      (frequency !== 'CUSTOM' || Boolean(customDays))
+  );
+
+  /**
+   * The whole builder as the API body, carried in one hidden field so the
+   * dynamic line-item list survives the form post intact. Only what the server
+   * accepts is sent; org/created_by/subtotal/total_amount/invoices_generated
+   * are its to derive, so none are here.
+   */
+  let payload = $derived.by(() => {
+    /** @type {Record<string, any>} */
+    const body = {
+      account_id: accountId,
+      contact_id: contactId,
+      title: title.trim(),
+      frequency,
+      payment_terms: paymentTerms,
+      currency,
+      start_date: startDate,
+      next_generation_date: nextGenerationDate,
+      auto_send: autoSend
+    };
+    if (frequency === 'CUSTOM' && customDays) body.custom_days = num(customDays);
+    if (endDate) body.end_date = endDate;
+    if (discountType) {
+      body.discount_type = discountType;
+      body.discount_value = num(discountValue);
+    }
+    if (num(taxRate)) body.tax_rate = num(taxRate);
+    if (notes.trim()) body.notes = notes.trim();
+    if (terms.trim()) body.terms = terms.trim();
+    if (usableLines.length) {
+      body.line_items = usableLines.map((l) => {
+        /** @type {Record<string, any>} */
+        const row = {
+          name: l.name.trim(),
+          description: (l.description || '').trim(),
+          quantity: num(l.quantity),
+          unit_price: num(l.unit_price)
+        };
+        if (l.product) row.product = l.product;
+        return row;
+      });
+    }
+    return body;
+  });
+
+  function addLine() {
+    items.push({ name: '', description: '', quantity: 1, unit_price: 0, product: null });
+  }
+
+  function addProduct(id) {
+    const p = data.products.find((x) => x.id === id);
+    if (!p) return;
+    items.push({
+      name: p.name,
+      description: p.sku,
+      quantity: 1,
+      unit_price: p.price,
+      product: p.id
+    });
+  }
+
+  function removeLine(i) {
+    items.splice(i, 1);
+    if (!items.length) addLine();
+  }
+</script>
+
+<PageHeader title="New schedule">
+  {#snippet sub()}
+    Nothing generates until the first run date arrives. Saving creates the schedule
+  {/snippet}
+  {#snippet actions()}
+    <a class="v2-btn" href="/invoices/recurring">Cancel</a>
+    <button type="submit" form="recurring-form" class="v2-btn v2-btn-primary" disabled={!ready}>
+      Save schedule
+    </button>
+  {/snippet}
+</PageHeader>
+
+<SectionTabs set="invoices" />
+
+{#if form?.error}
+  <div class="v2-pad" style="padding-top:12px">
+    <p class="new-error" role="alert">{form.error}</p>
+  </div>
+{/if}
+
+<!-- The builder posts as one JSON field so the dynamic line list travels whole.
+     The submit button lives in the header and is wired to this form by id. -->
+<form id="recurring-form" method="POST" action="?/create" use:enhance>
+  <input type="hidden" name="payload" value={JSON.stringify(payload)} />
+</form>
+
+<div class="v2-scroll">
+  <div class="v2-pad" style="padding-top:18px;padding-bottom:32px">
+    <div class="v2-split">
+      <!-- the form -->
+      <div>
+        <div class="v2-card" style="padding:16px 18px">
+          <div class="v2-label" style="margin-bottom:12px">Who and what</div>
+
+          <div class="grid2">
+            <label class="f">
+              <span>Account</span>
+              <select bind:value={accountId} onchange={() => (contactId = '')}>
+                <option value="">Choose an account</option>
+                {#each data.accounts as a (a.id)}
+                  <option value={a.id}>{a.name}</option>
+                {/each}
+              </select>
+            </label>
+
+            <label class="f">
+              <span>Contact</span>
+              <select bind:value={contactId} disabled={!accountId}>
+                <option value="">{accountId ? 'Choose a contact' : 'Pick an account first'}</option>
+                {#each contactOptions as c (c.id)}
+                  <option value={c.id}
+                    >{c.name}{c.account_name ? ` · ${c.account_name}` : ''}</option
+                  >
+                {/each}
+              </select>
+            </label>
+
+            <label class="f" style="grid-column:1/-1">
+              <span>Title</span>
+              <input bind:value={title} placeholder="What this schedule is for" required />
+            </label>
+          </div>
+        </div>
+
+        <div class="v2-card" style="padding:16px 18px;margin-top:14px">
+          <div class="v2-label" style="margin-bottom:12px">Cadence</div>
+
+          <div class="grid2">
+            <label class="f">
+              <span>Frequency</span>
+              <select bind:value={frequency}>
+                {#each Object.entries(RECURRING_FREQUENCY_LABEL) as [value, label] (value)}
+                  <option {value}>{label}</option>
+                {/each}
+              </select>
+            </label>
+
+            {#if frequency === 'CUSTOM'}
+              <label class="f">
+                <span>Every N days</span>
+                <input type="number" min="1" step="1" bind:value={customDays} required />
+              </label>
+            {/if}
+
+            <label class="f">
+              <span>Start date</span>
+              <input type="date" bind:value={startDate} />
+            </label>
+
+            <label class="f">
+              <span>Next generation date</span>
+              <input type="date" bind:value={nextGenerationDate} />
+            </label>
+
+            <label class="f">
+              <span>End date <span class="opt">(optional)</span></span>
+              <input type="date" bind:value={endDate} />
+            </label>
+
+            <label class="f">
+              <span>Payment terms</span>
+              <select bind:value={paymentTerms}>
+                {#each Object.entries(PAYMENT_TERMS_LABEL) as [value, label] (value)}
+                  <option {value}>{label}</option>
+                {/each}
+              </select>
+            </label>
+
+            <label class="f">
+              <span>Currency</span>
+              <select bind:value={currency}>
+                {#each CURRENCIES as c (c)}
+                  <option value={c}>{c}</option>
+                {/each}
+              </select>
+            </label>
+          </div>
+
+          <label class="check">
+            <input type="checkbox" bind:checked={autoSend} />
+            <span>
+              Send automatically when generated
+              <span class="hint-inline">off leaves a draft for you to review and send</span>
+            </span>
+          </label>
+        </div>
+
+        <div class="v2-card" style="padding:16px 18px;margin-top:14px">
+          <div style="display:flex;align-items:center;gap:12px;margin-bottom:12px">
+            <div class="v2-label">Lines <span class="opt">(optional)</span></div>
+            <select
+              class="catalogue"
+              value=""
+              onchange={(e) => {
+                addProduct(e.currentTarget.value);
+                e.currentTarget.value = '';
+              }}
+            >
+              <option value="">Add from catalogue…</option>
+              {#each data.products as p (p.id)}
+                <option value={p.id}>{p.name}, {money(p.price, currency)}</option>
+              {/each}
+            </select>
+          </div>
+
+          {#each items as item, i (i)}
+            <div class="line">
+              <div class="line-main">
+                <input class="line-name" bind:value={item.name} placeholder="Description" />
+                <input
+                  class="line-desc"
+                  bind:value={item.description}
+                  placeholder="Detail the customer sees under the name (optional)"
+                />
+              </div>
+              <label class="line-n">
+                <span>Qty</span>
+                <input type="number" min="0" step="1" bind:value={item.quantity} />
+              </label>
+              <label class="line-n">
+                <span>Unit price</span>
+                <input type="number" min="0" step="0.01" bind:value={item.unit_price} />
+              </label>
+              <div class="line-total v2-num">
+                {money(num(item.quantity) * num(item.unit_price), currency)}
+              </div>
+              <button
+                class="line-del"
+                onclick={() => removeLine(i)}
+                aria-label="Remove this line"
+                title="Remove this line"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          {/each}
+
+          <button class="v2-btn v2-btn-sm" style="margin-top:10px" onclick={addLine}>
+            <Plus size={13} />Add a line
+          </button>
+        </div>
+
+        <div class="v2-card" style="padding:16px 18px;margin-top:14px">
+          <div class="v2-label" style="margin-bottom:12px">Adjustments</div>
+          <div class="grid2">
+            <label class="f">
+              <span>Discount</span>
+              <select bind:value={discountType}>
+                <option value="">None</option>
+                <option value="PERCENTAGE">Percentage</option>
+                <option value="FIXED">Fixed amount</option>
+              </select>
+            </label>
+            {#if discountType}
+              <label class="f">
+                <span>{discountType === 'PERCENTAGE' ? 'Percent off' : 'Amount off'}</span>
+                <input type="number" min="0" step="0.01" bind:value={discountValue} />
+              </label>
+            {/if}
+            <label class="f">
+              <span>Tax rate %</span>
+              <input type="number" min="0" step="0.01" bind:value={taxRate} />
+            </label>
+          </div>
+          <p class="hint">Tax applies to the subtotal after the discount, on every invoice raised.</p>
+        </div>
+
+        <div class="v2-card" style="padding:16px 18px;margin-top:14px">
+          <div class="v2-label" style="margin-bottom:8px">Notes to the customer</div>
+          <textarea rows="3" bind:value={notes} placeholder="Appears on every invoice raised"
+          ></textarea>
+          <div class="v2-label" style="margin:14px 0 8px">Terms</div>
+          <textarea rows="3" bind:value={terms} placeholder="Payment terms and conditions"
+          ></textarea>
+        </div>
+      </div>
+
+      <!-- what each generated invoice will total, from the lines priced in so far -->
+      <div>
+        <div class="v2-card preview">
+          <div class="v2-card-head">
+            <span class="v2-label">Each invoice this schedule raises</span>
+          </div>
+          <div style="padding:14px 16px 16px">
+            {#if usableLines.length}
+              <PortalLineItems
+                items={usableLines}
+                {currency}
+                {subtotal}
+                {discountAmount}
+                {discountType}
+                {discountValue}
+                {taxRate}
+                {taxAmount}
+                {total}
+              />
+            {:else}
+              <p class="empty">
+                Lines are optional here. Add one to preview what each generated invoice will total, or
+                save the schedule without pricing it yet.
+              </p>
+            {/if}
+          </div>
+        </div>
+
+        <div class="v2-card" style="padding:15px 16px;margin-top:14px">
+          <div class="v2-label" style="margin-bottom:9px">On save</div>
+          <dl class="derived">
+            <dt>Subtotal, total</dt>
+            <dd>Recalculated by the server on every save and every generated invoice</dd>
+            <dt>Visibility</dt>
+            <dd>
+              Any signed-in teammate may create one. After that only the creator, an assignee, or
+              an admin can see or change it, and this form has no way to add an assignee, so only
+              you and an admin will see this schedule
+            </dd>
+          </dl>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<style>
+  .grid2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px 14px;
+  }
+  .f {
+    display: block;
+    min-width: 0;
+  }
+  .f > span {
+    display: block;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--v2-slate);
+    margin-bottom: 4px;
+  }
+  .opt {
+    text-transform: none;
+    font-weight: 500;
+    letter-spacing: 0;
+    color: var(--v2-slate);
+  }
+  input,
+  select,
+  textarea {
+    width: 100%;
+    padding: 7px 9px;
+    font: inherit;
+    font-size: 13px;
+    color: var(--v2-ink);
+    background: var(--v2-card);
+    border: 1px solid var(--v2-line);
+    border-radius: 6px;
+  }
+  textarea {
+    resize: vertical;
+    line-height: 1.5;
+  }
+  input:focus,
+  select:focus,
+  textarea:focus {
+    outline: 2px solid var(--v2-ember);
+    outline-offset: -1px;
+  }
+  input[type='number'] {
+    font-family: var(--v2-mono);
+    font-size: 12.5px;
+  }
+
+  .check {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin-top: 14px;
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .check input {
+    width: auto;
+    margin-top: 3px;
+  }
+  .hint-inline {
+    display: block;
+    font-size: 11.5px;
+    color: var(--v2-slate);
+  }
+
+  .catalogue {
+    width: auto;
+    margin-left: auto;
+    font-size: 12px;
+    padding: 5px 8px;
+  }
+
+  .line {
+    display: grid;
+    grid-template-columns: 72px 116px 1fr 26px;
+    gap: 9px;
+    align-items: end;
+    padding: 9px 0;
+    border-bottom: 1px solid var(--v2-line-soft);
+  }
+  .line-main {
+    grid-column: 1 / -1;
+    min-width: 0;
+  }
+  .line-desc {
+    margin-top: 5px;
+    font-size: 12px;
+    color: var(--v2-slate);
+  }
+  .line-n > span {
+    display: block;
+    font-size: 10px;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--v2-slate);
+    margin-bottom: 3px;
+  }
+  .line-total {
+    font-size: 13px;
+    font-weight: 600;
+    text-align: right;
+    min-width: 74px;
+    padding-bottom: 8px;
+  }
+  .line-del {
+    background: none;
+    border: 0;
+    padding: 0 0 9px;
+    color: var(--v2-slate);
+    cursor: pointer;
+  }
+  .line-del:hover {
+    color: var(--v2-rust);
+  }
+
+  .hint {
+    margin: 10px 0 0;
+    font-size: 11.5px;
+    color: var(--v2-slate);
+    line-height: 1.5;
+  }
+  #recurring-form {
+    display: contents;
+  }
+  .new-error {
+    margin: 0;
+    padding: 9px 12px;
+    font-size: 12.5px;
+    color: var(--v2-clay);
+    background: color-mix(in srgb, var(--v2-clay) 8%, transparent);
+    border: 1px solid color-mix(in srgb, var(--v2-clay) 25%, transparent);
+    border-radius: 7px;
+  }
+
+  .preview {
+    position: sticky;
+    top: 0;
+  }
+  .empty {
+    margin: 0;
+    font-size: 12.5px;
+    color: var(--v2-slate);
+    line-height: 1.5;
+  }
+  .derived {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 5px 14px;
+    margin: 0;
+    font-size: 12.5px;
+  }
+  .derived dt {
+    color: var(--v2-slate);
+  }
+  .derived dd {
+    margin: 0;
+  }
+
+  @media (max-width: 768px) {
+    .line-del {
+      min-width: 40px;
+      min-height: 40px;
+      padding: 0 0 9px;
+    }
+  }
+  @media (max-width: 560px) {
+    .line {
+      grid-template-columns: 1fr 1fr auto 40px;
+    }
+    .grid2 {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/frontend/src/routes/(app)/invoices/templates/+page.svelte
+++ b/frontend/src/routes/(app)/invoices/templates/+page.svelte
@@ -48,7 +48,7 @@
   {/snippet}
   {#snippet actions()}
     {#if canManage}
-      <button class="v2-btn v2-btn-primary"><Plus />New template</button>
+      <a class="v2-btn v2-btn-primary" href="/invoices/templates/new"><Plus />New template</a>
     {/if}
   {/snippet}
 </PageHeader>
@@ -120,8 +120,34 @@
             {/if}
 
             {#if canManage}
-              <div style="display:flex;gap:7px;margin-top:14px">
-                <button class="v2-btn v2-btn-sm">Edit</button>
+              <div style="display:flex;gap:7px;margin-top:14px;flex-wrap:wrap;align-items:center">
+                <!-- Disabled on purpose, not hidden: a control that quietly
+                     does nothing is the defect this phase fixes elsewhere.
+                     The REAL reason edit is out of scope: the detail GET
+                     (`GET /invoices/templates/<id>/`) answers with
+                     `InvoiceTemplateListSerializer`, same as the list, which
+                     never returns `template_html` or `template_css` (see
+                     templates.js). An edit form here could not pre-fill the
+                     custom markup, so it could not show what is actually
+                     saved. This is a data-shape gap, not a missing endpoint:
+                     `PUT /invoices/templates/<id>/` exists, is admin-gated,
+                     and is already `partial=True`
+                     (backend/invoices/api_views.py:1639), so editing every
+                     OTHER field, name, colours, logo, notes, terms, footer,
+                     is_default, would need no backend change at all.
+
+                     The reason is also rendered as visible text next to the
+                     button, not only in `title`: a disabled control is out of
+                     the tab order and its title is not announced by
+                     assistive tech. -->
+                <button
+                  class="v2-btn v2-btn-sm"
+                  disabled
+                  title="Editing isn't wired yet. The detail view never returns the custom HTML/CSS, so a form here couldn't show what's already saved. Every other field could be edited without a backend change."
+                >
+                  Edit
+                </button>
+                <span class="v2-sub" style="font-size:11px">Editing isn't wired yet</span>
                 {#if !t.is_default}
                   <!-- Named as the swap it is: one default exists at a time.
                        `is_default` is a singleton the model enforces, so this

--- a/frontend/src/routes/(app)/invoices/templates/new/+page.server.js
+++ b/frontend/src/routes/(app)/invoices/templates/new/+page.server.js
@@ -1,0 +1,61 @@
+import { fail, redirect } from '@sveltejs/kit';
+import { createInvoiceTemplate } from '$lib/server/v2/templates.js';
+import { readableError } from '$lib/server/v2/form-errors.js';
+
+/**
+ * Creating a template.
+ *
+ * Admin-only: `POST /api/invoices/templates/` refuses a non-admin via
+ * `_forbid_non_admin_template_write`, so this mirrors the products/new and
+ * goals/new pattern: `load` computes `can_manage` from `locals.profile.role`
+ * (same source the list page's `load` already uses) so a non-admin who
+ * navigates here directly sees an "admins only" state instead of a form the
+ * POST would refuse. The list page's own button is gated the same way.
+ *
+ * @type {import('./$types').PageServerLoad}
+ */
+export function load({ locals }) {
+  return { can_manage: /** @type {any} */ (locals)?.profile?.role === 'ADMIN' };
+}
+
+/**
+ * Read only the fields this form owns. Anything else in the submission is
+ * ignored here and would be dropped by the allow-list in the data layer too.
+ *
+ * @param {FormData} form
+ */
+function readValues(form) {
+  return {
+    name: form.get('name')?.toString() ?? '',
+    primary_color: form.get('primary_color')?.toString() ?? '',
+    secondary_color: form.get('secondary_color')?.toString() ?? '',
+    default_notes: form.get('default_notes')?.toString() ?? '',
+    default_terms: form.get('default_terms')?.toString() ?? '',
+    footer_text: form.get('footer_text')?.toString() ?? '',
+    is_default: form.get('is_default') === 'on'
+  };
+}
+
+/** @type {import('./$types').Actions} */
+export const actions = {
+  create: async ({ cookies, request }) => {
+    const form = await request.formData();
+    const logo = form.get('logo');
+    const logoFile = logo instanceof File && logo.size > 0 ? logo : null;
+    const values = readValues(form);
+
+    try {
+      await createInvoiceTemplate({ cookies }, values, logoFile);
+    } catch (/** @type {any} */ err) {
+      return fail(err?.status === 403 ? 403 : 400, {
+        values,
+        error:
+          err?.status === 403
+            ? 'Only an admin can create an invoice template.'
+            : readableError(err, 'Could not create the template.')
+      });
+    }
+
+    redirect(303, '/invoices/templates');
+  }
+};

--- a/frontend/src/routes/(app)/invoices/templates/new/+page.svelte
+++ b/frontend/src/routes/(app)/invoices/templates/new/+page.svelte
@@ -1,0 +1,202 @@
+<script>
+  /**
+   * A new invoice template: name, the two brand colours, an optional logo, and
+   * the boilerplate text (notes, terms, footer) new invoices start with.
+   *
+   * SCOPE, ON PURPOSE. No `template_html` / `template_css` input anywhere on
+   * this page, and no `{@html}` anywhere in this app. Both fields are org-
+   * authored markup that WeasyPrint renders into a PDF server-side; every read
+   * serializer (list AND detail) strips them, so a value written from a form
+   * here could never be read back or edited afterwards, a write-once field
+   * that is invisible from the moment it is saved. See `templates.js` for the
+   * full reasoning.
+   *
+   * VALIDATION HERE IS A UX HINT, NOT A RULE. `POST /api/invoices/templates/`
+   * is admin-gated (`_forbid_non_admin_template_write`) and enforces that
+   * regardless of what this page shows; curl and the mobile client reach the
+   * API without passing through here. The two colour inputs use
+   * `type="color"` so the browser can only ever submit a valid six-digit hex
+   * value: the server has no format validator on either field (only
+   * `max_length=7`), so a text input would make the client check the only
+   * thing standing between "purple" and a broken PDF.
+   */
+  import { enhance } from '$app/forms';
+  import PageHeader from '$lib/v2/components/PageHeader.svelte';
+  import { ChevronRight, Lock } from '@lucide/svelte';
+
+  /** @type {{ data: any, form: any }} */
+  let { data, form } = $props();
+
+  let values = $derived(form?.values ?? {});
+</script>
+
+<PageHeader title="New template" record center width="62ch">
+  {#snippet crumb()}
+    <a href="/invoices/templates">Templates</a>
+    <ChevronRight size={12} />
+    <span>New</span>
+  {/snippet}
+</PageHeader>
+
+<div class="v2-scroll">
+  {#if !data.can_manage}
+    <div class="v2-pad" style="padding-top:24px;max-width:56ch;margin-left:auto;margin-right:auto">
+      <div class="v2-next" role="note">
+        <Lock size={17} style="flex:none" />
+        <div class="v2-next-body">
+          <div style="font-weight:600">Admins only</div>
+          <div class="v2-sub" style="margin-top:2px">
+            Invoice templates are shared config for the whole org, every invoice's look, so only an
+            administrator can create one. You can still see how existing templates look on the
+            templates page.
+          </div>
+        </div>
+      </div>
+      <a class="v2-btn" href="/invoices/templates" style="margin-top:16px">Back to templates</a>
+    </div>
+  {:else}
+    <form
+      method="POST"
+      action="?/create"
+      enctype="multipart/form-data"
+      use:enhance
+      class="v2-pad"
+      style="padding-top:18px;padding-bottom:36px;max-width:62ch;margin-left:auto;margin-right:auto"
+    >
+      {#if form?.error}
+        <p style="color:var(--v2-rust);font-size:12.5px;margin:0 0 14px" role="alert">
+          {form.error}
+        </p>
+      {/if}
+
+      <label class="v2-field">
+        <span class="v2-label">Name</span>
+        <input
+          class="v2-input"
+          name="name"
+          required
+          maxlength="100"
+          value={values.name ?? ''}
+          placeholder="Standard invoice"
+        />
+      </label>
+
+      <div class="color-row">
+        <label class="color-field">
+          <span class="v2-label">Primary colour</span>
+          <input
+            class="color-swatch"
+            type="color"
+            name="primary_color"
+            value={values.primary_color || '#3B82F6'}
+          />
+        </label>
+        <label class="color-field">
+          <span class="v2-label">Secondary colour</span>
+          <input
+            class="color-swatch"
+            type="color"
+            name="secondary_color"
+            value={values.secondary_color || '#1E40AF'}
+          />
+        </label>
+      </div>
+      <p class="v2-sub" style="font-size:11.5px;margin:-6px 0 16px">
+        Picked, not typed, so the value sent is always a valid six digit hex. The API stores
+        whatever it is given here with no format check.
+      </p>
+
+      <label class="v2-field">
+        <span class="v2-label">Logo <span class="opt">(optional)</span></span>
+        <input class="v2-input" type="file" name="logo" accept="image/*" />
+      </label>
+
+      <label class="v2-field">
+        <span class="v2-label">Default notes <span class="opt">(optional)</span></span>
+        <textarea
+          class="v2-input"
+          name="default_notes"
+          rows="3"
+          placeholder="Thanks for your business."
+          >{values.default_notes ?? ''}</textarea
+        >
+      </label>
+
+      <label class="v2-field">
+        <span class="v2-label">Default terms <span class="opt">(optional)</span></span>
+        <textarea
+          class="v2-input"
+          name="default_terms"
+          rows="3"
+          placeholder="Payment due within 30 days."
+          >{values.default_terms ?? ''}</textarea
+        >
+      </label>
+
+      <label class="v2-field">
+        <span class="v2-label">Footer text <span class="opt">(optional)</span></span>
+        <textarea class="v2-input" name="footer_text" rows="2"
+          >{values.footer_text ?? ''}</textarea
+        >
+      </label>
+
+      <label class="flag">
+        <input type="checkbox" name="is_default" checked={values.is_default === true} />
+        <span>
+          <strong>Make this the default template</strong>
+          <span class="v2-sub">
+            Only one template can be the default at a time. Turning this on replaces whichever
+            template holds it now, new invoices will print with this one instead.
+          </span>
+        </span>
+      </label>
+
+      <div style="display:flex;gap:9px;margin-top:6px">
+        <button class="v2-btn v2-btn-primary" type="submit">Create template</button>
+        <a class="v2-btn" href="/invoices/templates">Cancel</a>
+      </div>
+    </form>
+  {/if}
+</div>
+
+<style>
+  .opt {
+    text-transform: none;
+    font-weight: 500;
+    letter-spacing: 0;
+    color: var(--v2-slate);
+  }
+  .color-row {
+    display: flex;
+    gap: 16px;
+  }
+  .color-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .color-swatch {
+    width: 56px;
+    height: 38px;
+    padding: 3px;
+    border: 1px solid var(--v2-line);
+    border-radius: 8px;
+    background: var(--v2-card);
+    cursor: pointer;
+  }
+  .flag {
+    display: flex;
+    gap: 9px;
+    align-items: flex-start;
+    font-size: 13px;
+    margin: 4px 0 18px;
+  }
+  .flag span {
+    display: block;
+  }
+  .flag .v2-sub {
+    display: block;
+    font-size: 11.5px;
+    margin-top: 2px;
+  }
+</style>

--- a/frontend/src/routes/(app)/leads/[id]/+page.server.js
+++ b/frontend/src/routes/(app)/leads/[id]/+page.server.js
@@ -1,5 +1,6 @@
 import { fail } from '@sveltejs/kit';
-import { addLeadNote, getLead } from '$lib/server/v2/leads.js';
+import { addLeadNote, convertLead, getLead } from '$lib/server/v2/leads.js';
+import { readableError } from '$lib/server/v2/form-errors.js';
 
 /** @type {import('./$types').PageServerLoad} */
 export async function load({ cookies, params }) {
@@ -42,5 +43,26 @@ export const actions = {
     }
 
     return { noted: true };
+  },
+
+  /**
+   * Convert this lead. The backend owns every rule: ownership, the one-way-door
+   * check, and the email requirement. This action adds no rule of its own, it
+   * only turns the API's rejection into a readable line for the page.
+   */
+  convert: async ({ cookies, params }) => {
+    try {
+      const result = await convertLead({ cookies }, params.id);
+      return {
+        converted: true,
+        account_id: result?.account_id ?? null,
+        contact_id: result?.contact_id ?? null,
+        opportunity_id: result?.opportunity_id ?? null
+      };
+    } catch (/** @type {any} */ err) {
+      return fail(err?.status === 403 ? 403 : 400, {
+        error: readableError(err, 'Could not convert this lead.')
+      });
+    }
   }
 };

--- a/frontend/src/routes/(app)/leads/[id]/+page.svelte
+++ b/frontend/src/routes/(app)/leads/[id]/+page.svelte
@@ -8,11 +8,13 @@
    * because the daily act on a lead is recording that you contacted them.
    *
    * WHAT IS NOT FAKED
-   * Conversion is a POST the community backend does not expose. There is no
-   * convert endpoint in `leads/urls.py`, so the Convert button stays disabled
-   * and says so, rather than pretending. The headline is derived only from
-   * fields the model actually has; where the data cannot support a sentence,
-   * there is no banner. The duplicate warning is a real query (see
+   * Conversion is not a dedicated endpoint. It is a PATCH of `status` on the
+   * ordinary lead detail URL (see `convertLead`), which runs
+   * `convert_lead_to_account` server-side: it creates an Account, a Contact
+   * when the lead has an email, and usually an Opportunity. It is a one-way
+   * door, the API refuses a repeat conversion. The headline is derived only
+   * from fields the model actually has; where the data cannot support a
+   * sentence, there is no banner. The duplicate warning is a real query (see
    * `findDuplicates`) and renders only when there is a match.
    */
   import PageHeader from '$lib/v2/components/PageHeader.svelte';
@@ -246,14 +248,53 @@
                     : ''}. The lead stays linked, and there is no endpoint that undoes it.
                 </p>
               </div>
-              <!-- Disabled, not hidden. Conversion is a POST this backend does
-                   not expose; hiding the button would hide the goal of the page. -->
-              <button class="v2-btn" disabled title="Conversion is not available yet">
-                Convert lead
-              </button>
+              <form method="POST" action="?/convert" use:enhance>
+                <!-- `disabled={!lead.email}` is a UX hint that mirrors the
+                     server-side guard the backend enforces on this same PATCH.
+                     It is not the enforcement: a request that skips this button
+                     entirely still meets the same rule server-side. The reason
+                     is also rendered as visible text below, not only in
+                     `title`: a disabled control is out of the tab order and
+                     its title is not announced by assistive tech. -->
+                <button
+                  class="v2-btn"
+                  type="submit"
+                  disabled={!lead.email}
+                  title={lead.email
+                    ? 'Creates an account, a contact and an opportunity from this lead'
+                    : 'Add an email address to this lead first. The contact record is created from it.'}
+                >
+                  Convert lead
+                </button>
+                {#if !lead.email}
+                  <p class="v2-sub" style="margin:4px 0 0;font-size:11.5px">
+                    Add an email address first. The contact record is created from it.
+                  </p>
+                {/if}
+              </form>
             </div>
           {/if}
         </div>
+
+        {#if form?.converted}
+          <div class="v2-card" role="status" style="margin-top:12px;padding:15px 16px">
+            <div class="v2-label" style="margin-bottom:6px">Converted</div>
+            <p class="v2-sub" style="margin:0 0 8px;font-size:12.5px;line-height:1.55">
+              The account, contact and deal are ready.
+            </p>
+            <div style="display:flex;gap:8px;flex-wrap:wrap">
+              <a class="v2-btn" href="/accounts/{form.account_id}">View account</a>
+              {#if form.contact_id}
+                <a class="v2-btn" href="/contacts/{form.contact_id}">View contact</a>
+              {/if}
+              {#if form.opportunity_id}
+                <a class="v2-btn" href="/pipeline/{form.opportunity_id}">View deal</a>
+              {/if}
+            </div>
+          </div>
+        {:else if form?.error}
+          <p class="note-err" style="margin-top:10px">{form.error}</p>
+        {/if}
 
         {#if lead.description}
           <div class="v2-label" style="margin:22px 0 10px">About</div>

--- a/frontend/src/routes/(app)/leads/[id]/edit/+page.server.js
+++ b/frontend/src/routes/(app)/leads/[id]/edit/+page.server.js
@@ -69,8 +69,10 @@ export const actions = {
       });
     }
 
+    /** @type {any} */
+    let result;
     try {
-      await updateLead({ cookies }, params.id, values);
+      result = await updateLead({ cookies }, params.id, values);
     } catch (/** @type {any} */ err) {
       // `api-helpers` flattens DRF's field errors into one string. Surface it
       // rather than a generic failure: "email: lead with this email already
@@ -78,6 +80,14 @@ export const actions = {
       return fail(400, { values, message: String(err?.message ?? 'Could not save this lead.') });
     }
 
-    return { saved: true };
+    // A save that also converted the lead (status -> "converted") carries the
+    // three created records in `result`. An ordinary field save does not, so
+    // these are null and the extra links never render.
+    return {
+      saved: true,
+      account_id: result?.account_id ?? null,
+      contact_id: result?.contact_id ?? null,
+      opportunity_id: result?.opportunity_id ?? null
+    };
   }
 };

--- a/frontend/src/routes/(app)/leads/[id]/edit/+page.svelte
+++ b/frontend/src/routes/(app)/leads/[id]/edit/+page.svelte
@@ -198,10 +198,30 @@
     {#if saved}
       <div class="v2-next" style="margin-bottom:18px" role="status">
         <div class="v2-next-body">
-          <div class="v2-next-text">Saved.</div>
-          <div class="v2-sub" style="margin-top:3px">
-            Changes to “{displayName}” are on the record.
-          </div>
+          {#if result?.account_id}
+            <div class="v2-next-text">Converted.</div>
+            <div class="v2-sub" style="margin-top:3px">
+              The account, contact and deal are ready. Converting is handled on its own, so only
+              custom fields from this save were applied; every other edit on this form was not.
+              Reopen the lead and redo them.
+            </div>
+          {:else}
+            <div class="v2-next-text">Saved.</div>
+            <div class="v2-sub" style="margin-top:3px">
+              Changes to “{displayName}” are on the record.
+            </div>
+          {/if}
+          {#if result?.account_id}
+            <div style="display:flex;gap:8px;flex-wrap:wrap;margin-top:8px">
+              <a class="v2-btn" href="/accounts/{result.account_id}">View account</a>
+              {#if result.contact_id}
+                <a class="v2-btn" href="/contacts/{result.contact_id}">View contact</a>
+              {/if}
+              {#if result.opportunity_id}
+                <a class="v2-btn" href="/pipeline/{result.opportunity_id}">View deal</a>
+              {/if}
+            </div>
+          {/if}
         </div>
         <a class="v2-btn" href="/leads/{lead.id}">Back to the lead</a>
       </div>
@@ -403,6 +423,10 @@
           An Account, a Contact and an Opportunity, with this lead's comments and attachments moved
           across. The lead stays as a converted record, and this is the last time you can change its
           status. There is no endpoint that undoes any of it.
+        </p>
+        <p style="margin-top:6px">
+          Any other change on this form, aside from custom fields, is dropped when it saves
+          alongside a conversion. Reopen the lead afterwards to redo it.
         </p>
       </div>
     {:else if statusChanged}

--- a/frontend/src/routes/(app)/settings/tags/+page.server.js
+++ b/frontend/src/routes/(app)/settings/tags/+page.server.js
@@ -1,5 +1,5 @@
 import { fail } from '@sveltejs/kit';
-import { getTags, createTag } from '$lib/server/v2/tags.js';
+import { getTags, createTag, archiveTag, restoreTag } from '$lib/server/v2/tags.js';
 import { readableError } from '$lib/server/v2/form-errors.js';
 
 /** @type {import('./$types').PageServerLoad} */
@@ -33,5 +33,48 @@ export const actions = {
     // No redirect. The list is on this page, and `load` re-runs after an
     // action, so the new tag appears where the user is already looking.
     return { created: true };
+  },
+
+  // Turns a tag off. Admin-only on the backend (`TagsDetailView.delete`),
+  // same split as `create`: `can_edit` hides the control for a member, this
+  // branch is what actually matters if that hint is bypassed. The backend
+  // soft-archives (`is_active = False`); it never deletes the row, so the
+  // error copy below stays consistent with that, nothing here talks about
+  // removal.
+  async archive(event) {
+    const form = await event.request.formData();
+    const id = form.get('id')?.toString() ?? '';
+    if (!id) return fail(400, { archive: { error: 'That tag could not be identified.' } });
+
+    try {
+      await archiveTag(event, id);
+    } catch (/** @type {any} */ err) {
+      if (err?.status === 403) {
+        return fail(403, { archive: { error: 'Only an admin can turn a tag off.' } });
+      }
+      return fail(400, {
+        archive: { error: readableError(err, 'Could not turn that tag off.') }
+      });
+    }
+    return { archived: true };
+  },
+
+  // Turns an archived tag back on. Same admin-only gate as `archive`.
+  async restore(event) {
+    const form = await event.request.formData();
+    const id = form.get('id')?.toString() ?? '';
+    if (!id) return fail(400, { restore: { error: 'That tag could not be identified.' } });
+
+    try {
+      await restoreTag(event, id);
+    } catch (/** @type {any} */ err) {
+      if (err?.status === 403) {
+        return fail(403, { restore: { error: 'Only an admin can turn a tag back on.' } });
+      }
+      return fail(400, {
+        restore: { error: readableError(err, 'Could not turn that tag back on.') }
+      });
+    }
+    return { restored: true };
   }
 };

--- a/frontend/src/routes/(app)/settings/tags/+page.svelte
+++ b/frontend/src/routes/(app)/settings/tags/+page.svelte
@@ -16,6 +16,7 @@
   import Pill from '$lib/v2/components/Pill.svelte';
   import StatCard from '$lib/v2/components/StatCard.svelte';
   import EmptyState from '$lib/v2/components/EmptyState.svelte';
+  import ConfirmAction from '$lib/v2/components/ConfirmAction.svelte';
   import { count } from '$lib/v2/format.js';
   import { Plus, Merge, Tags as TagsIcon } from '@lucide/svelte';
 
@@ -36,6 +37,16 @@
 
   let totals = $derived(data.totals);
 
+  /**
+   * Sums the four models the backend's `_TAGGABLE` list
+   * (`backend/common/views/tags_views.py:22-27`) counts: accounts, leads,
+   * opportunities (deals) and cases (tickets). `Contact` and `Task` also
+   * declare `tags = ManyToManyField(Tags, ...)` and accept tag writes through
+   * their own APIs, plus the contacts CSV importer, but `_TAGGABLE` does not
+   * include them, so this total, and the "unused" totals card below, are
+   * partial: a tag can carry real usage on contacts or tasks and still show
+   * as unused here.
+   */
   const used = (t) => t.usage.accounts + t.usage.leads + t.usage.opportunities + t.usage.cases;
 
   let tags = $derived(
@@ -127,7 +138,7 @@
       label="Applied to nothing"
       value={count(totals.unused)}
       tone={totals.unused > 0 ? 'clay' : 'slate'}
-      detail="Safe to delete"
+      detail="Counts accounts, leads, deals and tickets only"
     />
     <StatCard label="Turned off" value={count(totals.count - totals.active)} tone="slate" />
   </div>
@@ -153,6 +164,13 @@
       </div>
     {/each}
 
+    {#if form?.archive?.error}
+      <p class="v2-error" style="margin-bottom:12px">{form.archive.error}</p>
+    {/if}
+    {#if form?.restore?.error}
+      <p class="v2-error" style="margin-bottom:12px">{form.restore.error}</p>
+    {/if}
+
     <div class="v2-label" style="margin-bottom:10px">All tags</div>
     <div class="v2-table-wrap">
       <table class="v2-table">
@@ -165,6 +183,7 @@
             <th style="text-align:right">Tickets</th>
             <th style="text-align:right">Total</th>
             <th></th>
+            {#if data.can_edit}<th></th>{/if}
           </tr>
         </thead>
         <tbody>
@@ -190,10 +209,39 @@
                   <Pill tone="clay">Unused</Pill>
                 {/if}
               </td>
+              {#if data.can_edit}
+                <td style="text-align:right">
+                  {#if t.is_active}
+                    <!-- `TagsDetailView.delete` soft-archives: it flips
+                         `is_active` to false and leaves the row (and every
+                         record's link to it) in place. "Turn off", not
+                         "Delete", says what actually happens, and the count
+                         below is the real number already computed by `used`,
+                         not a vague warning. -->
+                    <ConfirmAction
+                      action="?/archive"
+                      label="Turn off"
+                      confirmLabel="Turn off"
+                      explain={used(t) > 0
+                        ? `${used(t)} ${used(t) === 1 ? 'account, lead, deal or ticket keeps' : 'accounts, leads, deals and tickets keep'} this tag (contacts and tasks can carry it too, but are not counted here). Turning it off stops it being offered on new records. You can turn it back on.`
+                        : 'No account, lead, deal or ticket carries this tag. Contacts and tasks can also carry tags but are not counted here, so this is not the full picture. Turning it off stops it being offered on new records. You can turn it back on.'}
+                      hidden={{ id: t.id }}
+                    />
+                  {:else}
+                    <!-- Turning a tag back on restores nothing that was
+                         destroyed, so unlike "Turn off" this doesn't need the
+                         two-click confirm. -->
+                    <form method="POST" action="?/restore" use:enhance>
+                      <input type="hidden" name="id" value={t.id} />
+                      <button class="v2-btn v2-btn-sm" type="submit">Turn back on</button>
+                    </form>
+                  {/if}
+                </td>
+              {/if}
             </tr>
           {:else}
             <tr>
-              <td colspan="7">
+              <td colspan={data.can_edit ? 8 : 7}>
                 <EmptyState
                   title="No tags yet"
                   body="Tags are shared across every record type, so the first one is worth naming carefully."
@@ -209,8 +257,7 @@
 
     <p class="v2-sub" style="font-size:11.5px;margin-top:14px;max-width:64ch">
       Turning a tag off hides it from the pickers and leaves it on the records that already carry
-      it. Deleting removes it everywhere, which is why the unused ones are the only safe ones to
-      delete.
+      it. Nothing is removed, and you can turn a tag back on at any time.
     </p>
   </div>
 </div>

--- a/frontend/test/stubs/env-dynamic-public.js
+++ b/frontend/test/stubs/env-dynamic-public.js
@@ -1,0 +1,6 @@
+// Stub for SvelteKit's $env/dynamic/public, which does not exist outside a Vite/SvelteKit build.
+// Unit tests here mock the network layer, so the value only has to be present, not correct.
+
+export const env = {
+  PUBLIC_DJANGO_API_URL: 'http://localhost:8000'
+};


### PR DESCRIPTION
…st actions

- Updated the template list page to link to a new template creation page.
- Implemented a new server-side route for creating invoice templates, including form handling and validation.
- Created a new Svelte component for the template creation form, allowing users to input template details.
- Added admin-only checks to restrict access to template creation.
- Enhanced the template list page with informative disabled buttons for editing templates.

feat(leads): implement lead conversion functionality

- Added a new action to convert leads, creating associated accounts, contacts, and opportunities.
- Updated the lead detail page to include a form for converting leads, with appropriate UX hints.
- Enhanced the lead edit page to display conversion results and links to newly created records.

feat(tags): implement tag archiving and restoring functionality

- Added actions for archiving and restoring tags, with appropriate error handling.
- Updated the tags management page to include controls for archiving and restoring tags.
- Enhanced user feedback for tag actions, including error messages and confirmation prompts.

test: add stub for dynamic public environment variables

- Created a stub for SvelteKit's $env/dynamic/public to facilitate unit testing without a full build.