### PR TITLE
fix(opportunity): fix dead creator check in kanban move RBAC

### DIFF
--- a/backend/opportunity/views/kanban_views.py
+++ b/backend/opportunity/views/kanban_views.py
@@ -182,7 +182,7 @@ class OpportunityMoveView(APIView):
 
         # Match Opportunity update/delete RBAC: admin OR creator OR assignee.
         if not is_org_admin(request.profile) and not request.user.is_superuser:
-            is_owner = request.profile == opportunity.created_by
+            is_owner = request.profile.user_id == opportunity.created_by_id
             is_assignee = request.profile in opportunity.assigned_to.all()
             if not (is_owner or is_assignee):
                 return Response(


### PR DESCRIPTION
`OpportunityMoveView` (`PATCH /api/opportunities/<pk>/move/`) compared
`request.profile` (a `Profile`) to `opportunity.created_by` (a `User` FK), which
is never equal, so `is_owner` was always `False`. A non-admin creator who isn't
also an assignee got **403** when moving their own deal on the kanban board.

Fix — compare user ids, as done elsewhere in these views:

```python
-            is_owner = request.profile == opportunity.created_by
+            is_owner = request.profile.user_id == opportunity.created_by_id