### PR TITLE
fix(api-settings): include id in the list serializer

### DIFF
--- a/backend/common/serializer.py
+++ b/backend/common/serializer.py
@@ -879,6 +879,7 @@ class APISettingsListSerializer(serializers.ModelSerializer):
     class Meta:
         model = APISettings
         fields = [
+            "id",
             "title",
             "apikey",
             "website",


### PR DESCRIPTION
`APISettingsListSerializer` omitted `id` from its fields, so list rows had no
identifier — clients can't target a row to edit or delete. Added `id`.