### PR TITLE
feat: enhance API settings serializer to conditionally expose `apikey…

### DIFF
--- a/backend/common/serializer.py
+++ b/backend/common/serializer.py
@@ -26,6 +26,7 @@ from common.models import (
     Teams,
     User,
 )
+from common.permissions import is_org_admin
 from common.utils import CURRENCY_SYMBOLS
 from common.validators import flexible_phone_validator
 
@@ -879,6 +880,7 @@ class APISettingsListSerializer(serializers.ModelSerializer):
     class Meta:
         model = APISettings
         fields = [
+            "id",
             "title",
             "apikey",
             "website",
@@ -888,6 +890,31 @@ class APISettingsListSerializer(serializers.ModelSerializer):
             "tags",
             "org",
         ]
+
+    def to_representation(self, instance):
+        """`apikey` is a live credential, so only an admin reads it back.
+
+        It is the sole thing `CreateLeadFromSite` authenticates on (see
+        `leads/views/lead_interactions.py`, which matches on the key alone and
+        has its website check commented out). Anyone holding it can post Lead
+        and Contact rows into the org anonymously, attributed to whoever
+        created the setting. Handing that to every USER-role member of the org
+        made a shared credential out of an admin one.
+
+        Unlike the `webhook_secret` on `InboundMailboxSerializer`, this cannot
+        be `write_only`: the key exists to be pasted into a website form, so
+        the admin who manages the integration has to read it back. Admin-only
+        on read is the same treatment `topic_arn` gets there.
+
+        Popped when the view passes no request in context, since a serializer
+        with no caller cannot prove the caller is an admin. Both call sites in
+        `common/views/settings_views.py` pass it.
+        """
+        data = super().to_representation(instance)
+        request = self.context.get("request")
+        if not is_org_admin(getattr(request, "profile", None)):
+            data.pop("apikey", None)
+        return data
 
 
 class APISettingsSwaggerSerializer(serializers.ModelSerializer):

--- a/backend/common/tests/test_settings.py
+++ b/backend/common/tests/test_settings.py
@@ -55,6 +55,59 @@ class TestDomainListView:
         response = unauthenticated_client.get(self.url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
+    def test_list_row_carries_its_id(self, admin_client, org_a, admin_user):
+        """The pk is the only way to reach the detail, update and delete routes.
+
+        It was missing from the serializer's ``fields``, and it appears in no
+        other response, so ``/api/api-settings/<pk>/`` was unreachable for
+        every caller including an admin. Pinned here because nothing else
+        asserts on the shape of a row.
+        """
+        setting = APISettings.objects.create(
+            title="Listed",
+            website="https://listed.com",
+            org=org_a,
+            created_by=admin_user,
+        )
+        response = admin_client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        rows = response.data["api_settings"]
+        assert str(rows[0]["id"]) == str(setting.pk)
+
+    def test_admin_reads_the_apikey(self, admin_client, org_a, admin_user):
+        """An admin has to read the key back: it is what they paste into the
+        website form that posts to ``CreateLeadFromSite``."""
+        setting = APISettings.objects.create(
+            title="Keyed", website="https://keyed.com", org=org_a, created_by=admin_user
+        )
+        response = admin_client.get(self.url)
+        assert response.data["api_settings"][0]["apikey"] == setting.apikey
+
+    def test_non_admin_does_not_read_the_apikey(self, user_client, org_a, admin_user):
+        """`apikey` authenticates the anonymous ``CreateLeadFromSite`` endpoint,
+        which creates Lead and Contact rows attributed to the setting's creator.
+        A USER-role member has no reason to hold it."""
+        APISettings.objects.create(
+            title="Keyed", website="https://keyed.com", org=org_a, created_by=admin_user
+        )
+        response = user_client.get(self.url)
+        assert response.status_code == status.HTTP_200_OK
+        row = response.data["api_settings"][0]
+        assert "apikey" not in row
+        # The rest of the row is still readable: this gates the credential, not
+        # the record.
+        assert row["title"] == "Keyed"
+
+    def test_non_admin_cannot_create(self, user_client, org_a):
+        """Creating an API setting mints a key that posts leads into the org."""
+        response = user_client.post(
+            self.url,
+            {"title": "Sneaky", "website": "https://sneaky.com"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert not APISettings.objects.filter(title="Sneaky").exists()
+
 
 @pytest.mark.django_db
 class TestDomainDetailView:
@@ -116,3 +169,45 @@ class TestDomainDetailView:
         setting = self._create_setting(org_a, admin_user)
         response = org_b_client.get(self._url(setting.pk))
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_admin_reads_the_apikey_on_detail(self, admin_client, org_a, admin_user):
+        setting = self._create_setting(org_a, admin_user)
+        response = admin_client.get(self._url(setting.pk))
+        assert response.data["domain"]["apikey"] == setting.apikey
+
+    def test_non_admin_does_not_read_the_apikey_on_detail(
+        self, user_client, org_a, admin_user
+    ):
+        """Detail is gated the same way as the list, or the list gate is a
+        speed bump: the pk is in every list row."""
+        setting = self._create_setting(org_a, admin_user)
+        response = user_client.get(self._url(setting.pk))
+        assert response.status_code == status.HTTP_200_OK
+        assert "apikey" not in response.data["domain"]
+
+    def test_non_admin_cannot_update(self, user_client, org_a, admin_user):
+        setting = self._create_setting(org_a, admin_user)
+        response = user_client.put(
+            self._url(setting.pk),
+            {"title": "Hijacked", "website": "https://attacker.example"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        setting.refresh_from_db()
+        assert setting.title == "Test Setting"
+
+    def test_non_admin_cannot_patch(self, user_client, org_a, admin_user):
+        setting = self._create_setting(org_a, admin_user)
+        response = user_client.patch(
+            self._url(setting.pk), {"title": "Hijacked"}, format="json"
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        setting.refresh_from_db()
+        assert setting.title == "Test Setting"
+
+    def test_non_admin_cannot_delete(self, user_client, org_a, admin_user):
+        """Deleting the setting breaks the org's website lead capture."""
+        setting = self._create_setting(org_a, admin_user)
+        response = user_client.delete(self._url(setting.pk))
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert APISettings.objects.filter(pk=setting.pk).exists()

--- a/backend/common/views/settings_views.py
+++ b/backend/common/views/settings_views.py
@@ -7,12 +7,20 @@ from rest_framework.views import APIView
 
 from common import swagger_params
 from common.models import APISettings, Profile, Tags
+from common.permissions import is_org_admin
 from common.serializer import (
     APISettingsListSerializer,
     APISettingsSerializer,
     APISettingsSwaggerSerializer,
     ProfileSerializer,
 )
+
+
+def _admin_required():
+    return Response(
+        {"error": True, "errors": "Admin access required"},
+        status=status.HTTP_403_FORBIDDEN,
+    )
 
 
 class DomainList(APIView):
@@ -42,7 +50,12 @@ class DomainList(APIView):
         return Response(
             {
                 "error": False,
-                "api_settings": APISettingsListSerializer(api_settings, many=True).data,
+                # Context carries the request so the serializer can decide
+                # whether this caller may read `apikey` back. Without it the
+                # key is withheld from everyone, admins included.
+                "api_settings": APISettingsListSerializer(
+                    api_settings, many=True, context={"request": request}
+                ).data,
                 "users": ProfileSerializer(users, many=True).data,
             },
             status=status.HTTP_200_OK,
@@ -64,6 +77,11 @@ class DomainList(APIView):
         },
     )
     def post(self, request, *args, **kwargs):
+        # Creating a setting mints an API key that posts leads into the org, so
+        # the write half of this endpoint is admin-only while the read half
+        # stays open to every member.
+        if not is_org_admin(request.profile):
+            return _admin_required()
         params = request.data
         assign_to_list = []
         if params.get("lead_assigned_to"):
@@ -116,7 +134,12 @@ class DomainDetailView(APIView):
     def get(self, request, pk, format=None):
         api_setting = self.get_object(pk)
         return Response(
-            {"error": False, "domain": APISettingsListSerializer(api_setting).data},
+            {
+                "error": False,
+                "domain": APISettingsListSerializer(
+                    api_setting, context={"request": request}
+                ).data,
+            },
             status=status.HTTP_200_OK,
         )
 
@@ -136,6 +159,8 @@ class DomainDetailView(APIView):
         },
     )
     def put(self, request, pk, **kwargs):
+        if not is_org_admin(request.profile):
+            return _admin_required()
         api_setting = self.get_object(pk)
         params = request.data
         assign_to_list = []
@@ -181,6 +206,8 @@ class DomainDetailView(APIView):
     )
     def patch(self, request, pk, **kwargs):
         """Handle partial updates to API settings."""
+        if not is_org_admin(request.profile):
+            return _admin_required()
         api_setting = self.get_object(pk)
         params = request.data
         serializer = APISettingsSerializer(
@@ -212,6 +239,8 @@ class DomainDetailView(APIView):
         },
     )
     def delete(self, request, pk, **kwargs):
+        if not is_org_admin(request.profile):
+            return _admin_required()
         api_setting = self.get_object(pk)
         if api_setting:
             api_setting.delete()

--- a/backend/leads/tests/test_leads_api.py
+++ b/backend/leads/tests/test_leads_api.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import patch
 
 import pytest
@@ -1774,7 +1775,13 @@ class TestLeadCommentAttachmentOnDetail:
     def test_post_comment_org_mismatch(
         self, org_b_client, admin_user, org_a, profile_b
     ):
-        """POSTing comment from different org gets 403 (line 488-492)."""
+        """POSTing a comment on another tenant's lead is a 404, not a 403.
+
+        A 403 here answered "that lead exists, but it isn't yours", which is a
+        cross-tenant existence leak: an outsider could probe ids and learn
+        which ones are real. Every other method on this view already answers
+        404 through ``get_object``, and ``put`` documents that as deliberate.
+        """
         lead = Lead.objects.create(
             first_name="OrgMismatch",
             last_name="Comment",
@@ -1787,10 +1794,25 @@ class TestLeadCommentAttachmentOnDetail:
             {"comment": "Wrong org"},
             format="json",
         )
-        assert response.status_code == 403
+        assert response.status_code == 404
+
+    def test_post_comment_unknown_lead(self, admin_client, org_a):
+        """An id that matches no lead is a 404, not a crash.
+
+        ``Lead.objects.get(pk=pk)`` raised ``DoesNotExist`` straight out of the
+        handler, so a well-formed id for a lead that had been deleted returned
+        a 500 to the caller and logged an exception on the server.
+        """
+        missing = uuid.uuid4()
+        response = admin_client.post(
+            _detail_url(missing),
+            {"comment": "No such lead"},
+            format="json",
+        )
+        assert response.status_code == 404
 
     def test_put_lead_org_mismatch(self, org_b_client, admin_user, org_a, profile_b):
-        """PUT from different org gets 403 (line 572)."""
+        """PUT on another tenant's lead is a 404, same as GET and POST."""
         lead = Lead.objects.create(
             first_name="OrgMismatchPut",
             last_name="Lead",
@@ -1807,11 +1829,12 @@ class TestLeadCommentAttachmentOnDetail:
             },
             format="json",
         )
-        # org_b_client has org_b in token but lead is in org_a - should get 404 from get_object
-        assert response.status_code in (403, 404)
+        # `in (403, 404)` here passed whichever way the view behaved, so it
+        # could not have caught the POST handler drifting to 403.
+        assert response.status_code == 404
 
     def test_patch_lead_org_mismatch(self, org_b_client, admin_user, org_a, profile_b):
-        """PATCH from different org gets 404 (line 727)."""
+        """PATCH on another tenant's lead is a 404, same as GET and POST."""
         lead = Lead.objects.create(
             first_name="OrgMismatchPatch",
             last_name="Lead",
@@ -1824,7 +1847,7 @@ class TestLeadCommentAttachmentOnDetail:
             {"first_name": "Hacked"},
             format="json",
         )
-        assert response.status_code in (403, 404)
+        assert response.status_code == 404
 
 
 @pytest.mark.django_db

--- a/backend/leads/views/lead_views.py
+++ b/backend/leads/views/lead_views.py
@@ -597,12 +597,11 @@ class LeadDetailView(APIView):
         params = request.data
 
         context = {}
-        self.lead_obj = Lead.objects.get(pk=pk)
-        if self.lead_obj.org != request.profile.org:
-            return Response(
-                {"error": True, "errors": "User company doesnot match with header...."},
-                status=status.HTTP_403_FORBIDDEN,
-            )
+        # `get_object` is what the other five methods on this view use, and it
+        # answers both failures this handler used to get wrong: an id matching
+        # no lead raised `DoesNotExist` out of the handler as a 500, and a lead
+        # in another tenant got a 403 that confirmed the id was real.
+        self.lead_obj = self.get_object(pk)
         if (
             not is_org_admin(self.request.profile)
             and not self.request.user.is_superuser
@@ -862,16 +861,10 @@ class LeadDetailView(APIView):
     def patch(self, request, pk, **kwargs):
         """Handle partial updates to a lead, including conversion."""
         params = request.data
+        # No org comparison after this. `get_object` filters on
+        # `org=self.request.profile.org`, so a mismatch is already a 404 and
+        # the 403 branch that used to sit here could never run.
         self.lead_obj = self.get_object(pk)
-
-        if self.lead_obj.org != request.profile.org:
-            return Response(
-                {
-                    "error": True,
-                    "errors": "User company does not match with header....",
-                },
-                status=status.HTTP_403_FORBIDDEN,
-            )
 
         if (
             not is_org_admin(self.request.profile)
@@ -1096,11 +1089,15 @@ class LeadDetailView(APIView):
     )
     def delete(self, request, pk, **kwargs):
         self.object = self.get_object(pk)
+        # The `and self.object.org == request.profile.org` conjunct that used
+        # to close this condition was always True: `get_object` already scoped
+        # the lookup to the caller's org. What remains is the role and
+        # ownership test, which is the only part that can answer False.
         if (
             is_org_admin(request.profile)
             or request.user.is_superuser
             or request.profile.user == self.object.created_by
-        ) and self.object.org == request.profile.org:
+        ):
             self.object.delete()
             return Response(
                 {"error": False, "message": "Lead deleted Successfully"},


### PR DESCRIPTION
…` for admins; add tests for access control