### PR TITLE
fix(accounts): make created_at range filter inclusive of the end day

### DIFF
--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -217,10 +217,10 @@ class AccountsListView(APIView, LimitOffsetPagination):
                 queryset = queryset.filter(name__icontains=params.get("search"))
             created_at_gte = date_param(params, "created_at__gte")
             if created_at_gte:
-                queryset = queryset.filter(created_at__gte=created_at_gte)
+                queryset = queryset.filter(created_at__date__gte=created_at_gte)
             created_at_lte = date_param(params, "created_at__lte")
             if created_at_lte:
-                queryset = queryset.filter(created_at__lte=created_at_lte)
+                queryset = queryset.filter(created_at__date__lte=created_at_lte)
             # Custom-field filters: ?cf_<key>=<value> -> custom_fields contains pair.
             for raw_key, raw_value in params.items():
                 if raw_key.startswith("cf_") and raw_value:


### PR DESCRIPTION
The accounts list parses `created_at__gte`/`created_at__lte` to a **date** but
filters the `created_at` **datetime** column, so the upper bound compares against
midnight and drops the rest of that day:

    ?created_at__lte=2026-01-01
    before:  WHERE created_at <= 2026-01-01 00:00:00+00:00
    after:   WHERE (created_at AT TIME ZONE UTC)::date <= 2026-01-01

Filtering on the date part (`__date__gte`/`__date__lte`) makes the range inclusive
by calendar day and timezone-correct. It also avoids the "naive datetime while time
zone support is active" RuntimeWarning the old comparison triggered.