### PR TITLE
fix(rls): exempt the /healthz/ liveness probe from RequireOrgContext

### DIFF
--- a/backend/common/middleware/rls_context.py
+++ b/backend/common/middleware/rls_context.py
@@ -169,7 +169,14 @@ class RequireOrgContext:
     # no org claim to require, and demanding one would fail sign-out in exactly
     # the case sign-out matters. Exact match: the view reads nothing but the
     # token in the body, and no sub-path should inherit this.
+    #
+    # GET /healthz/ is an unauthenticated liveness probe (load balancers, uptime
+    # monitors, container orchestrators). It renders a static template and reads
+    # no tenant data, so there is no org context to require. Gating it makes every
+    # health check return 403 and the service read as down. Exact match: nothing
+    # should hang off /healthz/.
     EXEMPT_EXACT_PATHS = [
+        "/healthz/",
         "/api/packs/",
         "/api/auth/logout/",
     ]


### PR DESCRIPTION
`RequireOrgContext` 403s any resolvable path that has no org context and isn't
exempt. `/healthz/` is in neither exempt list, so the liveness probe (a
`TemplateView`, no auth, no tenant data) gets 403, load balancers and uptime
monitors then read the service as down. Added `/healthz/` to `EXEMPT_EXACT_PATHS`.

**Question for maintainers:** two other endpoints hit the same 403 and look meant
to be reachable without org context, should they be exempt too?

- `POST /api/cases/inbound/<mailbox_id>/` - inbound-email webhook, called by an
  external provider (signature-authenticated), not by a logged-in user/org.
- `POST /api/leads/create-from-site/` - public website lead-capture form, submitted
  by anonymous visitors.

Happy to add them here or as separate PRs.
